### PR TITLE
db/seed-superadmin — SUPERADMIN user seed, all modules and rights seeded

### DIFF
--- a/db/migrations/006_seed_superadmin.sql
+++ b/db/migrations/006_seed_superadmin.sql
@@ -1,0 +1,88 @@
+-- ============================================================
+-- 006_seed_superadmin.sql
+-- Seed three SUPERADMIN accounts for Hope PMS
+-- Replace UUID placeholders with real values from Supabase Auth
+-- ============================================================
+
+-- STEP A: Insert SUPERADMIN rows into public.user
+INSERT INTO public.user (userId, username, lastName, firstName, user_type, record_status, stamp)
+VALUES
+  (
+    'AUTH_UUID_JCESPERANZA',
+    'Jerry',
+    'Esperanza',
+    'Jeremias',
+    'SUPERADMIN',
+    'ACTIVE',
+    'SEEDED jcesperanza ' || NOW()::TEXT
+  ),
+  (
+    'AUTH_UUID_JANICE',
+    'Janice',
+    'Hernandez',
+    'Janice',
+    'SUPERADMIN',
+    'ACTIVE',
+    'SEEDED janice.hernandez ' || NOW()::TEXT
+  ),
+  (
+    'AUTH_UUID_ANGELA',
+    'Angela',
+    'Militar',
+    'Angela',
+    'SUPERADMIN',
+    'ACTIVE',
+    'SEEDED angela.militar ' || NOW()::TEXT
+  )
+ON CONFLICT (userId) DO UPDATE
+  SET user_type     = EXCLUDED.user_type,
+      record_status = EXCLUDED.record_status,
+      username      = EXCLUDED.username,
+      lastName      = EXCLUDED.lastName,
+      firstName     = EXCLUDED.firstName,
+      stamp         = EXCLUDED.stamp;
+
+
+-- STEP B: Insert user_module rows (3 modules x 3 users = 9 rows)
+INSERT INTO public.user_module (userid, Module_ID, rights_value, record_status, stamp)
+VALUES
+  ('AUTH_UUID_JCESPERANZA', 'Prod_Mod',   1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_JCESPERANZA', 'Report_Mod', 1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_JCESPERANZA', 'Adm_Mod',   1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_JANICE',      'Prod_Mod',   1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_JANICE',      'Report_Mod', 1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_JANICE',      'Adm_Mod',   1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_ANGELA',      'Prod_Mod',   1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_ANGELA',      'Report_Mod', 1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_ANGELA',      'Adm_Mod',   1, 'ACTIVE', 'SEEDED')
+ON CONFLICT (userid, Module_ID) DO UPDATE
+  SET rights_value  = EXCLUDED.rights_value,
+      record_status = EXCLUDED.record_status,
+      stamp         = EXCLUDED.stamp;
+
+
+-- STEP C: Insert UserModule_Rights rows (6 rights x 3 users = 18 rows)
+INSERT INTO public.UserModule_Rights (userid, Right_ID, Right_value, Record_status, Stamp)
+VALUES
+  ('AUTH_UUID_JCESPERANZA', 'PRD_ADD',  1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_JCESPERANZA', 'PRD_EDIT', 1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_JCESPERANZA', 'PRD_DEL',  1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_JCESPERANZA', 'REP_001',  1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_JCESPERANZA', 'REP_002',  1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_JCESPERANZA', 'ADM_USER', 1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_JANICE',      'PRD_ADD',  1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_JANICE',      'PRD_EDIT', 1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_JANICE',      'PRD_DEL',  1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_JANICE',      'REP_001',  1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_JANICE',      'REP_002',  1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_JANICE',      'ADM_USER', 1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_ANGELA',      'PRD_ADD',  1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_ANGELA',      'PRD_EDIT', 1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_ANGELA',      'PRD_DEL',  1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_ANGELA',      'REP_001',  1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_ANGELA',      'REP_002',  1, 'ACTIVE', 'SEEDED'),
+  ('AUTH_UUID_ANGELA',      'ADM_USER', 1, 'ACTIVE', 'SEEDED')
+ON CONFLICT (userid, Right_ID) DO UPDATE
+  SET Right_value   = EXCLUDED.Right_value,
+      Record_status = EXCLUDED.Record_status,
+      Stamp         = EXCLUDED.Stamp;

--- a/db/migrations/007_rls_superadmin_protection.sql
+++ b/db/migrations/007_rls_superadmin_protection.sql
@@ -1,0 +1,28 @@
+-- ============================================================
+-- 007_rls_superadmin_protection.sql
+-- RLS policies protecting SUPERADMIN rows from ADMIN modification
+-- Project guide Section 7: SUPERADMIN Protection
+-- ============================================================
+
+CREATE POLICY admin_cannot_touch_superadmin
+ON public.user
+FOR UPDATE
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM public.user AS u
+    WHERE u.userId = auth.uid()::TEXT
+    AND u.user_type IN ('ADMIN', 'SUPERADMIN')
+  )
+  AND user_type != 'SUPERADMIN'
+);
+
+CREATE POLICY protect_superadmin_rights
+ON public.UserModule_Rights
+FOR ALL
+TO authenticated
+USING (
+  userid NOT IN (
+    SELECT userId FROM public.user WHERE user_type = 'SUPERADMIN'
+  )
+);


### PR DESCRIPTION
## What changed
- Migration 006: Seeded 3 SUPERADMIN accounts (jcesperanza, janice.hernandez, angela.militar)
  with user_type = SUPERADMIN, record_status = ACTIVE, all 6 rights = 1
- Migration 007: Added RLS policies blocking ADMIN from modifying SUPERADMIN rows
  in public.user and public.UserModule_Rights

## How to test
- Supabase SQL Editor → run Check 1–4 queries from Step 5
- Confirm 3 SUPERADMIN rows in public.user (all ACTIVE)
- Confirm 9 rows in user_module — all rights_value = 1
- Confirm 18 rows in UserModule_Rights — all Right_value = 1
- Authentication → Policies → confirm both protection policies are active