### PR TITLE
feat/ui-app-shell — Navbar, sidebar skeleton, layout wrapper

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,61 +1,70 @@
 // src/App.jsx
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
- 
+
 // Public pages
-import LoginPage from './pages/LoginPage';
-import RegisterPage from './pages/RegisterPage';
+import LoginPage        from './pages/LoginPage';
+import RegisterPage     from './pages/RegisterPage';
 import AuthCallbackPage from './pages/AuthCallbackPage';
- 
+
 // Protected pages
-import ProductsPage from './pages/ProductsPage';
-import ReportsPage from './pages/ReportsPage';
-import AdminPage from './pages/AdminPage';
+import ProductsPage     from './pages/ProductsPage';
+import ReportsPage      from './pages/ReportsPage';
+import AdminPage        from './pages/AdminPage';
 import DeletedItemsPage from './pages/DeletedItemsPage';
- 
-// Route guard
-import ProtectedRoute from './components/ProtectedRoute';
- 
+
+// Shell + guard
+import AppLayout        from './components/layout/AppLayout';
+import ProtectedRoute   from './components/ProtectedRoute';
+
 export default function App() {
   return (
     <BrowserRouter>
       <Routes>
- 
-        {/* Default redirect — root path sends to /login */}
+
+        {/* Default redirect */}
         <Route path="/" element={<Navigate to="/login" replace />} />
- 
-        {/* ── Public routes ── */}
-        <Route path="/login"          element={<LoginPage />} />
-        <Route path="/register"       element={<RegisterPage />} />
-        <Route path="/auth/callback"  element={<AuthCallbackPage />} />
- 
-        {/* ── Protected routes ── */}
+
+        {/* ── Public routes — no shell ── */}
+        <Route path="/login"         element={<LoginPage />} />
+        <Route path="/register"      element={<RegisterPage />} />
+        <Route path="/auth/callback" element={<AuthCallbackPage />} />
+
+        {/* ── Protected routes — wrapped in AppLayout ── */}
         <Route path="/products" element={
           <ProtectedRoute>
-            <ProductsPage />
+            <AppLayout>
+              <ProductsPage />
+            </AppLayout>
           </ProtectedRoute>
         } />
- 
+
         <Route path="/reports" element={
           <ProtectedRoute>
-            <ReportsPage />
+            <AppLayout>
+              <ReportsPage />
+            </AppLayout>
           </ProtectedRoute>
         } />
- 
+
         <Route path="/admin" element={
           <ProtectedRoute>
-            <AdminPage />
+            <AppLayout>
+              <AdminPage />
+            </AppLayout>
           </ProtectedRoute>
         } />
- 
+
         <Route path="/deleted-items" element={
           <ProtectedRoute>
-            <DeletedItemsPage />
+            <AppLayout>
+              <DeletedItemsPage />
+            </AppLayout>
           </ProtectedRoute>
         } />
- 
-        {/* Catch-all — unknown paths redirect to /login */}
+
+        {/* Catch-all */}
         <Route path="*" element={<Navigate to="/login" replace />} />
- 
+
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/layout/AppLayout.jsx
+++ b/src/components/layout/AppLayout.jsx
@@ -1,0 +1,26 @@
+// src/components/layout/AppLayout.jsx
+import Navbar from './Navbar';
+import Sidebar from './Sidebar';
+
+export default function AppLayout({ children }) {
+  return (
+    <div className="flex flex-col h-screen bg-gray-50">
+
+      {/* Top Navbar — fixed height, always visible */}
+      <Navbar />
+
+      {/* Body: Sidebar + Main content */}
+      <div className="flex flex-1 overflow-hidden">
+
+        {/* Left Sidebar */}
+        <Sidebar />
+
+        {/* Main content area — scrollable */}
+        <main className="flex-1 overflow-y-auto p-6">
+          {children}
+        </main>
+
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,0 +1,63 @@
+// src/components/layout/Sidebar.jsx
+import { NavLink } from 'react-router-dom';
+import { useAuth } from '../../hooks/useAuth';
+
+// Reusable NavLink style — active link gets a blue left border + background
+const linkClass = ({ isActive }) =>
+  `flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+    isActive
+      ? 'bg-blue-50 text-blue-700 border-l-4 border-blue-600'
+      : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+  }`;
+
+export default function Sidebar() {
+  const { currentUser } = useAuth();
+
+  // ── Role-based visibility ────────────────────────────────────
+  // From project guide Section 8.8:
+  // "Deleted Items" is visible only to ADMIN and SUPERADMIN
+  const canViewDeleted =
+    currentUser &&
+    ['ADMIN', 'SUPERADMIN'].includes(currentUser.user_type);
+
+  // "Admin" link: gated by ADM_USER right — placeholder for now.
+  // M4 (S2-T13) will replace this with: rights.ADM_USER === 1
+  // from UserRightsContext once it is built in Sprint 2.
+  const canViewAdmin =
+    currentUser && currentUser.user_type === 'SUPERADMIN';
+
+  return (
+    <aside className="w-56 bg-white border-r border-gray-200 flex flex-col py-4 shrink-0">
+
+      <nav className="flex flex-col gap-1 px-2">
+
+        {/* ── Always visible ── */}
+        <NavLink to="/products" className={linkClass}>
+          Products
+        </NavLink>
+
+        <NavLink to="/reports" className={linkClass}>
+          Reports
+        </NavLink>
+
+        {/* ── Deleted Items — ADMIN and SUPERADMIN only ── */}
+        {/* Project guide Section 8.8 — exact gating rule */}
+        {canViewDeleted && (
+          <NavLink to="/deleted-items" className={linkClass}>
+            Deleted Items
+          </NavLink>
+        )}
+
+        {/* ── Admin — SUPERADMIN only in Sprint 1 placeholder ── */}
+        {/* TODO (M4 — S2-T13): replace canViewAdmin with rights.ADM_USER === 1 */}
+        {canViewAdmin && (
+          <NavLink to="/admin" className={linkClass}>
+            Admin
+          </NavLink>
+        )}
+
+      </nav>
+
+    </aside>
+  );
+}

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -1,3 +1,9 @@
+// src/pages/AdminPage.jsx
 export default function AdminPage() {
-  return <div>Admin Page — placeholder</div>;
+  return (
+    <div>
+      <h2 className="text-xl font-semibold text-gray-800">Admin</h2>
+      <p className="text-sm text-gray-500 mt-1">Admin panel will appear here.</p>
+    </div>
+  );
 }

--- a/src/pages/ProductsPage.jsx
+++ b/src/pages/ProductsPage.jsx
@@ -1,3 +1,9 @@
-export default function ProductsPage(){
-  return <div>Products Page</div>
+// src/pages/ProductsPage.jsx
+export default function ProductsPage() {
+  return (
+    <div>
+      <h2 className="text-xl font-semibold text-gray-800">Products</h2>
+      <p className="text-sm text-gray-500 mt-1">Product list will appear here.</p>
+    </div>
+  );
 }

--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -1,3 +1,9 @@
-export default function ReportPage() {
-  return <div>Report Page — placeholder</div>;
+// src/pages/ReportsPage.jsx
+export default function ReportsPage() {
+  return (
+    <div>
+      <h2 className="text-xl font-semibold text-gray-800">Reports</h2>
+      <p className="text-sm text-gray-500 mt-1">Reports will appear here.</p>
+    </div>
+  );
 }


### PR DESCRIPTION
## What changed
- Created AppLayout.jsx — Navbar + Sidebar + scrollable main content area
- Created Navbar.jsx — app name, logged-in username display, logout button stub
- Created Sidebar.jsx — nav links with placeholder role gating:
    - Products, Reports: always visible
    - Deleted Items: ADMIN + SUPERADMIN only (Section 8.8 pattern)
    - Admin: SUPERADMIN placeholder (M4 replaces with ADM_USER right in S2-T13)
- Updated App.jsx — all protected routes wrapped in AppLayout
- Updated placeholder pages with minimal headings

## How to test
1. Temporarily update useAuth stub to return a mock currentUser
2. npm run dev → visit /products, /reports, /admin, /deleted-items
3. Confirm shell renders: Navbar + Sidebar + page content
4. Test sidebar gating per user_type (SUPERADMIN / ADMIN / USER)
5. Confirm NavLink active styles work on each link
6. Revert useAuth stub before merging