### PR TITLE
db/trigger-provision-user — provision_new_user() trigger deployed and tested

### DIFF
--- a/db/migrations/008_trigger_provision_user.sql
+++ b/db/migrations/008_trigger_provision_user.sql
@@ -3,38 +3,60 @@
 -- Auto-provisioning trigger: fires on every auth.users INSERT
 -- Creates public.user row as USER/INACTIVE with default
 -- module access and rights rows.
--- Project Guide Section 4.4
+-- Updated: NULLIF(TRIM(...)) for Google OAuth empty-string fields
 -- ============================================================
 
--- Drop existing function and trigger if re-deploying
 DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
 DROP FUNCTION IF EXISTS provision_new_user();
 
 CREATE OR REPLACE FUNCTION provision_new_user()
 RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER AS $$
+
 DECLARE
   v_username TEXT;
+
 BEGIN
+
+  -- Resolve username for Google OAuth users:
+  -- Google provides full_name in raw_user_meta_data.
+  -- NULLIF(TRIM(...), '') handles cases where Google sends an empty string.
+  -- Fallback: email prefix (part before '@').
   v_username := COALESCE(
-    NULLIF(TRIM(NEW.raw_user_meta_data->>'full_name'), ''),
+    NULLIF(TRIM(NEW.raw_user_meta_data->>'full_name'),  ''),
     split_part(NEW.email, '@', 1)
   );
 
+  -- Idempotent guard: skip provisioning if the user row already exists.
+  -- This protects SUPERADMIN accounts seeded in S1-T09.
   IF NOT EXISTS (SELECT 1 FROM public.user WHERE userId = NEW.id::TEXT) THEN
-    INSERT INTO public.user (userId, username, lastName, firstName, user_type, record_status, stamp)
-    VALUES (
-      NEW.id::TEXT, v_username,
-      COALESCE(NULLIF(TRIM(NEW.raw_user_meta_data->>'last_name'), ''), ''),
+
+    -- ── Insert public.user row ───────────────────────────────
+    INSERT INTO public.user (
+      userId,
+      username,
+      lastName,
+      firstName,
+      user_type,
+      record_status,
+      stamp
+    ) VALUES (
+      NEW.id::TEXT,
+      v_username,
+      COALESCE(NULLIF(TRIM(NEW.raw_user_meta_data->>'last_name'),  ''), ''),
       COALESCE(NULLIF(TRIM(NEW.raw_user_meta_data->>'first_name'), ''), v_username),
-      'USER', 'INACTIVE',
+      'USER',
+      'INACTIVE',
       'REGISTERED ' || NEW.id::TEXT || ' ' || NOW()::TEXT
     );
 
+    -- ── Insert user_module rows (default module access) ──────
     INSERT INTO public.user_module (userid, Module_ID, rights_value, record_status, stamp) VALUES
       (NEW.id::TEXT, 'Prod_Mod',   1, 'ACTIVE', 'AUTO'),
       (NEW.id::TEXT, 'Report_Mod', 1, 'ACTIVE', 'AUTO'),
       (NEW.id::TEXT, 'Adm_Mod',    0, 'ACTIVE', 'AUTO');
 
+    -- ── Insert UserModule_Rights rows (default rights) ───────
+    -- Table name quoted because of mixed casing
     INSERT INTO public."UserModule_Rights" (userid, "Right_ID", "Right_value", "Record_status", "Stamp") VALUES
       (NEW.id::TEXT, 'PRD_ADD',  1, 'ACTIVE', 'AUTO'),
       (NEW.id::TEXT, 'PRD_EDIT', 1, 'ACTIVE', 'AUTO'),
@@ -42,9 +64,11 @@ BEGIN
       (NEW.id::TEXT, 'REP_001',  1, 'ACTIVE', 'AUTO'),
       (NEW.id::TEXT, 'REP_002',  0, 'ACTIVE', 'AUTO'),
       (NEW.id::TEXT, 'ADM_USER', 0, 'ACTIVE', 'AUTO');
+
   END IF;
 
   RETURN NEW;
+
 END; $$;
 
 CREATE TRIGGER on_auth_user_created


### PR DESCRIPTION
## What changed
- Migration 008: provision_new_user() function + on_auth_user_created trigger
- Fires AFTER INSERT ON auth.users (Google OAuth)
- Creates public.user row: USER / INACTIVE
- Username: NULLIF(TRIM(full_name), '') or email prefix fallback
- Creates 3 user_module rows (Prod_Mod=1, Report_Mod=1, Adm_Mod=0)
- Creates 6 UserModule_Rights rows (PRD_ADD=1, PRD_EDIT=1, PRD_DEL=0,
  REP_001=1, REP_002=0, ADM_USER=0)
- IF NOT EXISTS guard — SUPERADMIN rows from S1-T09 not overwritten
- SECURITY DEFINER — required for trigger writing to public schema
- Quoted "UserModule_Rights" — handles mixed-case table name

## How to test
Run Checks 1–7 from Steps 4 and 5 in SQL Editor after a new Google sign-in