### PR TITLE
db/rls-product-select — SELECT policy (ACTIVE-only for USER, all for ADMIN/SUPERADMIN)

### DIFF
--- a/db/migrations/016_rls_product_select.sql
+++ b/db/migrations/016_rls_product_select.sql
@@ -1,0 +1,27 @@
+-- ============================================================
+-- 016_rls_product_select.sql
+-- RLS SELECT policy on public.product.
+-- Enforces that USER accounts only ever see ACTIVE rows,
+-- even via direct API calls. ADMIN and SUPERADMIN see all.
+-- Project guide Section 8.3 (Layer 1 — DB enforcement).
+-- ============================================================
+
+-- Drop if re-deploying (safe for re-runs)
+DROP POLICY IF EXISTS user_sees_active_only ON public.product;
+
+CREATE POLICY user_sees_active_only
+  ON public.product
+  FOR SELECT
+  TO authenticated
+  USING (
+    -- Row is visible if product is ACTIVE
+    record_status = 'ACTIVE'
+    OR
+    -- OR if the current user is ADMIN or SUPERADMIN
+    EXISTS (
+      SELECT 1
+      FROM public.user u
+      WHERE u.userid = auth.uid()::TEXT
+        AND u.user_type IN ('ADMIN', 'SUPERADMIN')
+    )
+  );


### PR DESCRIPTION
## What changed
- db/migrations/016_rls_product_select.sql
  Policy: user_sees_active_only on public.product FOR SELECT TO authenticated
  USING: record_status = 'ACTIVE'
    OR EXISTS (public.user WHERE userid = auth.uid() AND user_type IN ('ADMIN','SUPERADMIN'))
  Effect: USER accounts cannot read INACTIVE rows even via direct API calls.
  ADMIN and SUPERADMIN read all rows regardless of record_status.

## How to test
1. Insert a test INACTIVE product (ZZ9999)
2. Impersonate USER via SET LOCAL in SQL Editor → SELECT ZZ9999 → 0 rows
3. Impersonate SUPERADMIN → SELECT ZZ9999 → 1 row
4. App test: sign in as USER → getProducts('USER') → 0 INACTIVE rows
5. App test: sign in as SUPERADMIN → getDeletedProducts() → ZZ9999 appears