### PR TITLE
db/view-current-price — current_product_price SQL view

### DIFF
--- a/db/migrations/018_view_current_product_price.sql
+++ b/db/migrations/018_view_current_product_price.sql
@@ -1,0 +1,38 @@
+-- ============================================================
+-- 018_view_current_product_price.sql
+-- View: current_product_price
+--
+-- Returns the latest unit price for each ACTIVE product.
+-- One row per product. Products with no pricehist row excluded.
+--
+-- Used by:
+--   - getAllCurrentPrices() and getCurrentPrice() in priceHistService.js
+--   - ProductsPage Current Price column (S2-T04)
+--   - REP_001 Product Report (S3-T01, Sprint 3)
+-- ============================================================
+
+DROP VIEW IF EXISTS public.current_product_price;
+
+CREATE VIEW public.current_product_price AS
+SELECT
+  p.prodcode,
+  p.description,
+  p.unit,
+  p.record_status,
+  ph.unitprice,
+  ph.effdate
+FROM public.product p
+INNER JOIN public.pricehist ph
+  ON ph.prodcode = p.prodcode
+WHERE p.record_status = 'ACTIVE'
+  AND ph.effdate = (
+    SELECT MAX(ph2.effdate)
+    FROM public.pricehist ph2
+    WHERE ph2.prodcode = p.prodcode
+  )
+ORDER BY p.prodcode;
+
+-- Grant SELECT to the authenticated role (Supabase JS client)
+-- and anon role (needed for Supabase's internal query routing)
+GRANT SELECT ON public.current_product_price TO authenticated;
+GRANT SELECT ON public.current_product_price TO anon;


### PR DESCRIPTION
## What changed
- db/migrations/018_view_current_product_price.sql
  View: public.current_product_price
  Columns: prodcode, description, unit, record_status, unitprice, effdate
  Logic: INNER JOIN product + pricehist WHERE effdate = MAX(effdate per product)
  Filter: record_status = 'ACTIVE' — INACTIVE products never appear
  Grants: SELECT to authenticated and anon roles
  Security: security_invoker = true (PostgreSQL 15+ — respects RLS on product table)

## Why
- Removes the JS Map fallback in getAllCurrentPrices() / getCurrentPrice()
- ProductsPage Current Price column now reads directly from view
- Reused by REP_001 Product Report in Sprint 3 (S3-T01) without changes

## How to test
1. COUNT(*) → > 0 rows
2. GROUP BY prodcode HAVING COUNT > 1 → 0 rows (no duplicates)
3. AK0001 → unitprice matches highest effdate in pricehist
4. INACTIVE ZZ7777 with pricehist → not in view
5. App: /products Current Price populated; no fallback console message