### PR TITLE
feat/route-guard-deleted — /deleted-items blocked for USER accounts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,36 +9,43 @@ import AdminPage        from './pages/AdminPage';
 import DeletedItemsPage from './pages/DeletedItemsPage';
 import AppLayout        from './components/layout/AppLayout';
 import ProtectedRoute   from './components/ProtectedRoute';
+import RoleRoute        from './components/RoleRoute';
 
 export default function App() {
   return (
     <Routes>
       <Route path="/"              element={<Navigate to="/login" replace />} />
 
-      {/* Public routes */}
+      {/* Public */}
       <Route path="/login"         element={<LoginPage />} />
       <Route path="/register"      element={<Navigate to="/login" replace />} />
       <Route path="/auth/callback" element={<AuthCallbackPage />} />
 
-      {/* Protected routes */}
+      {/* Protected — session required */}
       <Route path="/products" element={
         <ProtectedRoute>
           <AppLayout><ProductsPage /></AppLayout>
         </ProtectedRoute>
       } />
+
       <Route path="/reports" element={
         <ProtectedRoute>
           <AppLayout><ReportsPage /></AppLayout>
         </ProtectedRoute>
       } />
+
       <Route path="/admin" element={
         <ProtectedRoute>
           <AppLayout><AdminPage /></AppLayout>
         </ProtectedRoute>
       } />
+
+      {/* Deleted Items — session required AND role must be ADMIN or SUPERADMIN */}
       <Route path="/deleted-items" element={
         <ProtectedRoute>
-          <AppLayout><DeletedItemsPage /></AppLayout>
+          <RoleRoute allowedRoles={['ADMIN', 'SUPERADMIN']}>
+            <AppLayout><DeletedItemsPage /></AppLayout>
+          </RoleRoute>
         </ProtectedRoute>
       } />
 

--- a/src/components/AppErrorBoundary.jsx
+++ b/src/components/AppErrorBoundary.jsx
@@ -1,0 +1,36 @@
+// Simple error boundary class for provider failures
+// src/components/AppErrorBoundary.jsx
+import { Component } from 'react';
+
+export default class AppErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex items-center justify-center bg-gray-50 p-8">
+          <div className="text-center">
+            <h2 className="text-lg font-bold text-gray-800 mb-2">Application Error</h2>
+            <p className="text-sm text-gray-500 mb-4">
+              Something went wrong. Please refresh the page.
+            </p>
+            <button
+              onClick={() => window.location.reload()}
+              className="bg-blue-600 text-white text-sm px-4 py-2 rounded-lg"
+            >
+              Refresh
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/RoleRoute.jsx
+++ b/src/components/RoleRoute.jsx
@@ -1,0 +1,31 @@
+// src/components/RoleRoute.jsx
+// Role-based route guard — runs inside ProtectedRoute.
+// Checks currentUser.user_type against allowedRoles.
+// Users with disallowed roles are silently redirected to /products.
+// Redirecting silently (no error message) follows the project guide pattern
+// for Deleted Items visibility (Section 8.5).
+
+import { Navigate } from 'react-router-dom';
+import { useAuth }  from '../hooks/useAuth';
+
+/**
+ * @param {string[]} allowedRoles - e.g. ['ADMIN', 'SUPERADMIN']
+ * @param {React.ReactNode} children
+ */
+export default function RoleRoute({ allowedRoles, children }) {
+  const { currentUser } = useAuth();
+
+  // currentUser may be null briefly while profile loads.
+  // ProtectedRoute handles the loading state — by the time we get here,
+  // currentUser should be populated. If null, deny access as a safe default.
+  if (!currentUser) {
+    return <Navigate to="/products" replace />;
+  }
+
+  if (!allowedRoles.includes(currentUser.user_type)) {
+    // Silent redirect — no error message shown (matches project guide Section 8.5)
+    return <Navigate to="/products" replace />;
+  }
+
+  return children;
+}

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -165,7 +165,7 @@ export function AuthProvider({ children }) {
     const rightsRows = DEFAULT_RIGHTS_ROWS.map(row => ({ ...row, userid: userId }));
 
     const { error: rightsError } = await supabase
-      .from('UserModule_Rights')
+      .from('usermodule_rights')
       .insert(rightsRows);
 
     if (rightsError) {

--- a/src/context/UserRightsContext.jsx
+++ b/src/context/UserRightsContext.jsx
@@ -60,7 +60,7 @@ export function UserRightsProvider({ children }) {
     try {
       // First attempt: lowercase column names
       const { data, error } = await supabase
-        .from('UserModule_Rights')
+        .from('usermodule_rights')
         .select('right_id, right_value, record_status')
         .eq('userid', userId);
  
@@ -71,7 +71,7 @@ export function UserRightsProvider({ children }) {
  
       // Second attempt: mixed-case column names (if table was created with quoted identifiers)
       const { data: data2, error: error2 } = await supabase
-        .from('UserModule_Rights')
+        .from('usermodule_rights')
         .select('"Right_ID", "Right_value", "Record_status"')
         .eq('userid', userId);
  

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,8 +1,9 @@
 // src/main.jsx
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
-import { AuthProvider } from './context/AuthContext.jsx';
+import { BrowserRouter }       from 'react-router-dom';
+import { AuthProvider }        from './context/AuthContext.jsx';
+import { UserRightsProvider }  from './context/UserRightsContext.jsx';
 import App from './App.jsx';
 import './index.css';
 
@@ -10,7 +11,10 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
       <AuthProvider>
-        <App />
+        {/* UserRightsProvider is inside AuthProvider so it can read currentUser */}
+        <UserRightsProvider>
+          <App />
+        </UserRightsProvider>
       </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,17 +1,20 @@
 // src/pages/LoginPage.jsx
-// FIXED: Auto-signout when landing on error pages so users are never stuck.
-// Google button passes prompt: 'select_account' so a different account can be chosen.
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth }  from '../hooks/useAuth';
 import { supabase } from '../lib/supabaseClient';
 
 export default function LoginPage() {
-  const { session, loading, signOut } = useAuth();
-  const navigate                      = useNavigate();
-  const [searchParams]                = useSearchParams();
+  const { session, loading, currentUser, signOut } = useAuth();
+  const navigate       = useNavigate();
+  const [searchParams] = useSearchParams();
 
   const errorParam = searchParams.get('error');
+
+  // Track whether the auto-signout on an error page has already completed.
+  // This prevents the redirect useEffect from firing while signout is still
+  // in progress, and also prevents double-signout calls.
+  const [signedOutForError, setSignedOutForError] = useState(false);
 
   const errorMessages = {
     not_activated:    'Your account is pending activation by an administrator.',
@@ -20,40 +23,73 @@ export default function LoginPage() {
 
   const displayError = errorMessages[errorParam] ?? '';
 
-  // FIX — Auto-signout on error arrival.
-  // When a user is redirected to /login?error=..., their Supabase session
-  // may still be active (e.g., if AuthCallbackPage did not sign them out first,
-  // or if they navigate directly). Signing out here ensures the session is
-  // cleared so clicking "Sign in with Google" starts a fresh flow.
+  // ── Effect 1: Auto-signout when landing on an error URL ──────
+  // Only runs when there is an error param in the URL.
+  // Signs out, then marks completion so Effect 2 can safely redirect.
+  // The auto-redirect to /login (clean) happens after signout resolves.
   useEffect(() => {
-    if (errorParam && !loading) {
-      signOut().catch(err =>
-        console.warn('Auto-signout on error page:', err.message)
-      );
-    }
-  }, [errorParam, loading, signOut]);
+    if (!errorParam || loading) return;
+    if (signedOutForError) return; // already handled
 
-  // Redirect to /products if already fully signed in with an ACTIVE session
+    signOut()
+      .catch(err => console.warn('Auto-signout on error page:', err.message))
+      .finally(() => {
+        setSignedOutForError(true);
+        // Replace the current URL with /login (no error param) so:
+        // 1. A page refresh does not re-trigger the error flow
+        // 2. The user sees the clean login page after signout
+        // Small delay gives React time to process the signout state update
+        setTimeout(() => {
+          navigate('/login', { replace: true });
+        }, 100);
+      });
+  }, [errorParam, loading]); // eslint-disable-line react-hooks/exhaustive-deps
+  // signOut and navigate are stable references — omitting to prevent
+  // the effect re-running on every render
+
+  // ── Effect 2: Redirect to /products for a valid active session ──
+  // Only fires when:
+  //   - No error param in URL (clean login page)
+  //   - Not currently signing out for an error
+  //   - Session confirmed by Supabase
+  //   - currentUser is loaded AND has record_status = ACTIVE
+  // This ensures a user with a persisted session (hard refresh, new tab)
+  // is sent straight to /products without having to click anything.
   useEffect(() => {
-    if (!loading && session) {
+    if (loading)       return; // session check still in progress
+    if (errorParam)    return; // error page — signout is handling this
+    if (!session)      return; // no session — stay on login
+
+    // Wait for the profile to load before checking activation status.
+    // currentUser is null while fetchUserProfile is in flight.
+    if (!currentUser)  return;
+
+    if (currentUser.record_status === 'ACTIVE') {
       navigate('/products', { replace: true });
     }
-  }, [session, loading, navigate]);
+    // If record_status is INACTIVE or null, stay on the login page.
+    // AuthCallbackPage handles the redirect for those cases during the
+    // OAuth flow. If the user somehow arrives here with an INACTIVE
+    // session, they just see the login page — which is correct.
+  }, [loading, session, currentUser, errorParam, navigate]);
 
   async function handleGoogleSignIn() {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
         redirectTo: `${window.location.origin}/auth/callback`,
-        // Force Google to show account picker every time.
-        // Prevents re-authenticating as a blocked account silently.
+        // Force Google to show account picker every time so the user
+        // can choose a different account if their previous one was blocked.
         queryParams: { prompt: 'select_account' },
       },
     });
     if (error) console.error('OAuth initiation error:', error.message);
   }
 
-  if (loading) {
+  // Show spinner while:
+  // - Initial session check is running (loading = true)
+  // - Or an error-param signout is in progress (not yet signedOutForError)
+  if (loading || (errorParam && !signedOutForError)) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50">
         <div className="w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
@@ -73,7 +109,8 @@ export default function LoginPage() {
             <p className="font-semibold mb-1">⚠️ Sign-in Issue</p>
             <p>{displayError}</p>
             <p className="text-xs mt-2 text-red-500">
-              You've been signed out. Please try signing in again, or use a different account.
+              You have been signed out. Please try signing in again,
+              or use a different account if needed.
             </p>
           </div>
         )}


### PR DESCRIPTION
## What changed
- src/components/RoleRoute.jsx — new role-based route guard
  Accepts allowedRoles prop; redirects to /products if user_type not in list
  Used inside ProtectedRoute (session guard runs first)
- src/main.jsx — UserRightsProvider added inside AuthProvider
  All pages now have access to useRights() from UserRightsContext (S2-T11)
- src/App.jsx — /deleted-items wrapped with ProtectedRoute + RoleRoute
  allowedRoles: ['ADMIN', 'SUPERADMIN']
  USER accessing /deleted-items silently redirected to /products
- src/context/ — renamed UserModule_Rights to usermodule_rights
- src/pages/login — fix reload delayed

## How to test
1. Sign in as SUPERADMIN → navigate to /deleted-items → page renders
2. Sign in as USER → type /deleted-items directly → silent redirect to /products
3. Sign out → visit /deleted-items → redirect to /login (ProtectedRoute)
4. Confirm no flash of DeletedItemsPage content before redirect for USER