### PR TITLE
feat/ui-product-crud — AddProductModal, EditProductModal, SoftDeleteConfirmDialog

### DIFF
--- a/src/components/products/AddProductModal.jsx
+++ b/src/components/products/AddProductModal.jsx
@@ -1,10 +1,195 @@
-// src/components/products/AddProductModal.jsx — placeholder
-export default function AddProductModal({ onClose }) {
+// src/components/products/AddProductModal.jsx
+import { useState, useEffect } from 'react';
+import { useAuth }      from '../../hooks/useAuth';
+import { addProduct }   from '../../services/productService';
+
+const UNIT_OPTIONS = ['pc', 'ea', 'mtr', 'pkg', 'ltr'];
+
+/**
+ * @param {Function} onClose   - Called when modal is dismissed without action
+ * @param {Function} onSuccess - Called after successful product creation
+ */
+export default function AddProductModal({ onClose, onSuccess }) {
+  const { currentUser } = useAuth();
+
+  const [prodcode,    setProdcode]    = useState('');
+  const [description, setDescription] = useState('');
+  const [unit,        setUnit]        = useState('pc');
+  const [loading,     setLoading]     = useState(false);
+  const [error,       setError]       = useState('');
+  const [fieldErrors, setFieldErrors] = useState({});
+
+  // Close on Escape key
+  useEffect(() => {
+    function handleKeyDown(e) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  // ── Validation ─────────────────────────────────────────────
+  function validate() {
+    const errors = {};
+
+    if (!prodcode.trim()) {
+      errors.prodcode = 'Product code is required.';
+    } else if (!/^[A-Z]{2}\d{4}$/.test(prodcode.trim().toUpperCase())) {
+      errors.prodcode = 'Format: 2 letters + 4 digits (e.g. AK0001).';
+    }
+
+    if (!description.trim()) {
+      errors.description = 'Description is required.';
+    } else if (description.trim().length > 30) {
+      errors.description = 'Description must be 30 characters or fewer.';
+    }
+
+    if (!UNIT_OPTIONS.includes(unit)) {
+      errors.unit = 'Select a valid unit.';
+    }
+
+    return errors;
+  }
+
+  // ── Submit ──────────────────────────────────────────────────
+  async function handleSubmit() {
+    setError('');
+    const errors = validate();
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    setFieldErrors({});
+    setLoading(true);
+
+    const { error: apiError } = await addProduct(
+      {
+        prodcode:    prodcode.trim().toUpperCase(),
+        description: description.trim(),
+        unit,
+      },
+      currentUser.userid
+    );
+
+    setLoading(false);
+
+    if (apiError) {
+      if (apiError.message?.includes('duplicate') || apiError.message?.includes('unique')) {
+        setError(`Product code "${prodcode.toUpperCase()}" already exists.`);
+      } else {
+        setError(apiError.message ?? 'Failed to add product. Please try again.');
+      }
+      return;
+    }
+
+    onSuccess();
+  }
+
+  // ── Render ──────────────────────────────────────────────────
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-2xl p-6 w-full max-w-sm text-center">
-        <p className="text-sm text-gray-500 mb-4">Add Product — placeholder (S2-T05)</p>
-        <button onClick={onClose} className="text-sm text-blue-600 hover:underline">Close</button>
+    <div
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 px-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-2xl shadow-xl w-full max-w-md"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <h3 className="text-base font-semibold text-gray-800">Add Product</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl leading-none">
+            ×
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-5 space-y-4">
+
+          {error && (
+            <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+          {/* Product Code */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Product Code
+            </label>
+            <input
+              type="text"
+              value={prodcode}
+              onChange={e => setProdcode(e.target.value.toUpperCase())}
+              placeholder="e.g. AK0001"
+              maxLength={6}
+              className={`w-full border rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500 uppercase ${
+                fieldErrors.prodcode ? 'border-red-400 bg-red-50' : 'border-gray-300'
+              }`}
+            />
+            {fieldErrors.prodcode && (
+              <p className="mt-1 text-xs text-red-600">{fieldErrors.prodcode}</p>
+            )}
+            <p className="mt-1 text-xs text-gray-400">2 letters + 4 digits. Cannot be changed after saving.</p>
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Description
+            </label>
+            <input
+              type="text"
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              placeholder="Product name or description"
+              maxLength={30}
+              className={`w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                fieldErrors.description ? 'border-red-400 bg-red-50' : 'border-gray-300'
+              }`}
+            />
+            {fieldErrors.description && (
+              <p className="mt-1 text-xs text-red-600">{fieldErrors.description}</p>
+            )}
+            <p className="mt-1 text-xs text-gray-400">{description.length}/30 characters</p>
+          </div>
+
+          {/* Unit */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Unit
+            </label>
+            <select
+              value={unit}
+              onChange={e => setUnit(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {UNIT_OPTIONS.map(u => (
+                <option key={u} value={u}>{u}</option>
+              ))}
+            </select>
+          </div>
+
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="text-sm text-gray-600 hover:text-gray-800 px-4 py-2"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={loading}
+            className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white text-sm font-medium px-5 py-2 rounded-lg transition-colors"
+          >
+            {loading ? 'Adding…' : 'Add Product'}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/products/EditProductModal.jsx
+++ b/src/components/products/EditProductModal.jsx
@@ -1,11 +1,171 @@
-// src/components/products/EditProductModal.jsx — placeholder
-export default function EditProductModal({ product, onClose }) {
+// src/components/products/EditProductModal.jsx
+import { useState, useEffect } from 'react';
+import { useAuth }        from '../../hooks/useAuth';
+import { updateProduct }  from '../../services/productService';
+
+const UNIT_OPTIONS = ['pc', 'ea', 'mtr', 'pkg', 'ltr'];
+
+/**
+ * @param {object}   product   - The product row selected in ProductsPage
+ * @param {Function} onClose
+ * @param {Function} onSuccess
+ */
+export default function EditProductModal({ product, onClose, onSuccess }) {
+  const { currentUser } = useAuth();
+
+  const [description, setDescription] = useState(product?.description ?? '');
+  const [unit,        setUnit]        = useState(product?.unit ?? 'pc');
+  const [loading,     setLoading]     = useState(false);
+  const [error,       setError]       = useState('');
+  const [fieldErrors, setFieldErrors] = useState({});
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKeyDown(e) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  function validate() {
+    const errors = {};
+    if (!description.trim()) {
+      errors.description = 'Description is required.';
+    } else if (description.trim().length > 30) {
+      errors.description = 'Description must be 30 characters or fewer.';
+    }
+    if (!UNIT_OPTIONS.includes(unit)) {
+      errors.unit = 'Select a valid unit.';
+    }
+    return errors;
+  }
+
+  async function handleSubmit() {
+    setError('');
+    const errors = validate();
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    setFieldErrors({});
+    setLoading(true);
+
+    const { error: apiError } = await updateProduct(
+      product.prodcode,
+      { description: description.trim(), unit },
+      currentUser.userid
+    );
+
+    setLoading(false);
+
+    if (apiError) {
+      setError(apiError.message ?? 'Failed to update product. Please try again.');
+      return;
+    }
+
+    onSuccess();
+  }
+
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-2xl p-6 w-full max-w-sm text-center">
-        <p className="text-sm text-gray-500 mb-1">Edit Product — placeholder (S2-T05)</p>
-        <p className="text-xs text-gray-400 mb-4">{product?.prodcode}</p>
-        <button onClick={onClose} className="text-sm text-blue-600 hover:underline">Close</button>
+    <div
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 px-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-2xl shadow-xl w-full max-w-md"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <div>
+            <h3 className="text-base font-semibold text-gray-800">Edit Product</h3>
+            <p className="text-xs text-gray-400 mt-0.5 font-mono">{product?.prodcode}</p>
+          </div>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl leading-none">
+            ×
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-5 space-y-4">
+
+          {error && (
+            <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+          {/* Product Code — read-only */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Product Code
+            </label>
+            <input
+              type="text"
+              value={product?.prodcode ?? ''}
+              readOnly
+              className="w-full border border-gray-200 bg-gray-50 rounded-lg px-3 py-2 text-sm font-mono text-gray-500 cursor-not-allowed"
+            />
+            <p className="mt-1 text-xs text-gray-400">Product code cannot be changed.</p>
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Description
+            </label>
+            <input
+              type="text"
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              maxLength={30}
+              className={`w-full border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                fieldErrors.description ? 'border-red-400 bg-red-50' : 'border-gray-300'
+              }`}
+            />
+            {fieldErrors.description && (
+              <p className="mt-1 text-xs text-red-600">{fieldErrors.description}</p>
+            )}
+            <p className="mt-1 text-xs text-gray-400">{description.length}/30 characters</p>
+          </div>
+
+          {/* Unit */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Unit
+            </label>
+            <select
+              value={unit}
+              onChange={e => setUnit(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {UNIT_OPTIONS.map(u => (
+                <option key={u} value={u}>{u}</option>
+              ))}
+            </select>
+          </div>
+
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="text-sm text-gray-600 hover:text-gray-800 px-4 py-2"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={loading}
+            className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white text-sm font-medium px-5 py-2 rounded-lg transition-colors"
+          >
+            {loading ? 'Saving…' : 'Save Changes'}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/products/SoftDeleteConfirmDialog.jsx
+++ b/src/components/products/SoftDeleteConfirmDialog.jsx
@@ -1,11 +1,109 @@
-// src/components/products/SoftDeleteConfirmDialog.jsx — placeholder
-export default function SoftDeleteConfirmDialog({ product, onClose }) {
+// src/components/products/SoftDeleteConfirmDialog.jsx
+import { useState, useEffect } from 'react';
+import { useAuth }             from '../../hooks/useAuth';
+import { softDeleteProduct }   from '../../services/productService';
+
+/**
+ * @param {object}   product   - The product row selected in ProductsPage
+ * @param {Function} onClose
+ * @param {Function} onSuccess
+ */
+export default function SoftDeleteConfirmDialog({ product, onClose, onSuccess }) {
+  const { currentUser } = useAuth();
+  const [loading, setLoading] = useState(false);
+  const [error,   setError]   = useState('');
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKeyDown(e) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  async function handleConfirm() {
+    setError('');
+    setLoading(true);
+
+    const { error: apiError } = await softDeleteProduct(
+      product.prodcode,
+      currentUser.userid
+    );
+
+    setLoading(false);
+
+    if (apiError) {
+      setError(apiError.message ?? 'Failed to delete product. Please try again.');
+      return;
+    }
+
+    onSuccess();
+  }
+
   return (
-    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-      <div className="bg-white rounded-2xl p-6 w-full max-w-sm text-center">
-        <p className="text-sm text-gray-500 mb-1">Soft Delete — placeholder (S2-T05)</p>
-        <p className="text-xs text-gray-400 mb-4">{product?.prodcode}</p>
-        <button onClick={onClose} className="text-sm text-blue-600 hover:underline">Close</button>
+    <div
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 px-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-2xl shadow-xl w-full max-w-sm"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <h3 className="text-base font-semibold text-gray-800">Delete Product</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl leading-none">
+            ×
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-5">
+
+          {error && (
+            <div className="mb-4 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+          {/* Warning icon + message */}
+          <div className="flex gap-3 items-start">
+            <span className="text-2xl mt-0.5">⚠️</span>
+            <div>
+              <p className="text-sm font-medium text-gray-800">
+                Are you sure you want to delete{' '}
+                <span className="font-mono font-bold">{product?.prodcode}</span>?
+              </p>
+              <p className="text-sm text-gray-500 mt-1">
+                <strong>{product?.description}</strong>
+              </p>
+              <p className="text-xs text-gray-400 mt-3">
+                This product will be hidden from all users but not permanently removed.
+                It can be recovered from the <strong>Deleted Items</strong> page.
+              </p>
+            </div>
+          </div>
+
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200">
+          <button
+            onClick={onClose}
+            disabled={loading}
+            className="text-sm text-gray-600 hover:text-gray-800 px-4 py-2"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={loading}
+            className="bg-red-600 hover:bg-red-700 disabled:bg-red-300 text-white text-sm font-medium px-5 py-2 rounded-lg transition-colors"
+          >
+            {loading ? 'Deleting…' : 'Yes, Delete'}
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## What changed
Replaces placeholder stubs from S2-T04 with full implementations:

- AddProductModal.jsx
    prodcode (PK, auto-uppercase, format validated), description (≤30 chars),
    unit (dropdown: pc/ea/mtr/pkg/ltr); calls addProduct(); duplicate key message
- EditProductModal.jsx
    prodcode read-only; description + unit editable; pre-filled from selected row;
    calls updateProduct(); description ≤30 validation
- SoftDeleteConfirmDialog.jsx
    Confirmation with product code + description; calls softDeleteProduct();
    explains product is hidden not deleted; recoverable from Deleted Items

All modals: Escape key closes; click overlay closes; loading state disables submit;
inline error messages; onSuccess() triggers handleDataChange() in ProductsPage.

## How to test
As SUPERADMIN:
- Add: valid inputs → product in list; duplicate → error; empty → field errors
- Edit: pre-filled; code read-only; description update → list reflects change
- Delete: confirm → product gone from list; DB shows INACTIVE, not deleted

<img width="1919" height="787" alt="Screenshot 2026-04-17 222814" src="https://github.com/user-attachments/assets/bf44b0d8-91fe-49e3-aa07-1501ac929beb" />
<img width="1919" height="787" alt="Screenshot 2026-04-17 222840" src="https://github.com/user-attachments/assets/61198777-89c2-44dc-99ee-bc7a28575421" />
<img width="1587" height="59" alt="Screenshot 2026-04-17 223203" src="https://github.com/user-attachments/assets/fd252647-761b-4d70-8290-b5f7eb7ad287" />
<img width="1919" height="795" alt="Screenshot 2026-04-17 223229" src="https://github.com/user-attachments/assets/a928fb69-8665-44d6-b435-ab2322546ce2" />
<img width="1919" height="761" alt="Screenshot 2026-04-17 223348" src="https://github.com/user-attachments/assets/2f162aec-0651-43eb-a185-de20035f5d5d" />
<img width="1514" height="65" alt="Screenshot 2026-04-17 223423" src="https://github.com/user-attachments/assets/dd376da3-69e9-4cb0-a7f2-b4a4df8db791" />
<img width="1919" height="680" alt="Screenshot 2026-04-17 223501" src="https://github.com/user-attachments/assets/b578cf65-8230-4273-9e5f-6d581635bca1" />
<img width="1536" height="51" alt="Screenshot 2026-04-18 095639" src="https://github.com/user-attachments/assets/ae394e3e-4c45-4cd5-a054-6bc42fa456b7" />
