### PR TITLE
feat/ui-price-history — PriceHistoryPanel + AddPriceEntryForm

### DIFF
--- a/src/components/products/AddPriceEntryForm.jsx
+++ b/src/components/products/AddPriceEntryForm.jsx
@@ -1,0 +1,137 @@
+// src/components/products/AddPriceEntryForm.jsx
+import { useState } from 'react';
+import { useAuth }        from '../../hooks/useAuth';
+import { addPriceEntry }  from '../../services/priceHistService';
+
+/**
+ * @param {string}   prodcode   - FK to product
+ * @param {Function} onSuccess  - Called after successful insert; parent re-fetches
+ */
+export default function AddPriceEntryForm({ prodcode, onSuccess }) {
+  const { currentUser } = useAuth();
+
+  const [effdate,     setEffdate]     = useState('');
+  const [unitprice,   setUnitprice]   = useState('');
+  const [loading,     setLoading]     = useState(false);
+  const [error,       setError]       = useState('');
+  const [fieldErrors, setFieldErrors] = useState({});
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  function validate() {
+    const errors = {};
+
+    if (!effdate) {
+      errors.effdate = 'Effective date is required.';
+    } else if (effdate > today) {
+      errors.effdate = 'Effective date cannot be in the future.';
+    }
+
+    const price = Number(unitprice);
+    if (!unitprice) {
+      errors.unitprice = 'Unit price is required.';
+    } else if (isNaN(price) || price <= 0) {
+      errors.unitprice = 'Unit price must be greater than 0.';
+    }
+
+    return errors;
+  }
+
+  async function handleSubmit() {
+    setError('');
+    const errors = validate();
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    setFieldErrors({});
+    setLoading(true);
+
+    const { error: apiError } = await addPriceEntry(
+      prodcode,
+      effdate,
+      Number(unitprice),
+      currentUser.userid
+    );
+
+    setLoading(false);
+
+    if (apiError) {
+      setError(apiError.message ?? 'Failed to add price entry. Please try again.');
+      return;
+    }
+
+    setEffdate('');
+    setUnitprice('');
+    onSuccess();
+  }
+
+  return (
+    <div className="border-t border-blue-200 pt-4 mt-2">
+      <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
+        Add New Price Entry
+      </p>
+
+      {error && (
+        <div className="mb-3 rounded-lg bg-red-50 border border-red-200 px-3 py-2 text-xs text-red-700">
+          {error}
+        </div>
+      )}
+
+      {/* Full-width row: date + price inputs stretch to fill, button at end */}
+      <div className="flex items-end gap-3 w-full">
+
+        {/* Effective Date — flex-1 so it grows */}
+        <div className="flex-1">
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Effective Date
+          </label>
+          <input
+            type="date"
+            value={effdate}
+            onChange={e => setEffdate(e.target.value)}
+            max={today}
+            className={`w-full border rounded-lg px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              fieldErrors.effdate ? 'border-red-400 bg-red-50' : 'border-gray-300'
+            }`}
+          />
+          {fieldErrors.effdate && (
+            <p className="mt-0.5 text-xs text-red-600">{fieldErrors.effdate}</p>
+          )}
+        </div>
+
+        {/* Unit Price — flex-1 so it grows */}
+        <div className="flex-1">
+          <label className="block text-xs font-medium text-gray-600 mb-1">
+            Unit Price (₱)
+          </label>
+          <input
+            type="number"
+            value={unitprice}
+            onChange={e => setUnitprice(e.target.value)}
+            min="0.01"
+            step="0.01"
+            placeholder="0.00"
+            className={`w-full border rounded-lg px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              fieldErrors.unitprice ? 'border-red-400 bg-red-50' : 'border-gray-300'
+            }`}
+          />
+          {fieldErrors.unitprice && (
+            <p className="mt-0.5 text-xs text-red-600">{fieldErrors.unitprice}</p>
+          )}
+        </div>
+
+        {/* Submit — fixed width, aligned to bottom */}
+        <button
+          onClick={handleSubmit}
+          disabled={loading}
+          className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-300 text-white text-xs font-medium px-4 py-1.5 rounded-lg transition-colors shrink-0"
+        >
+          {loading ? 'Adding…' : 'Add Price'}
+        </button>
+
+      </div>
+    </div>
+  );
+}

--- a/src/components/products/PriceHistoryPanel.jsx
+++ b/src/components/products/PriceHistoryPanel.jsx
@@ -1,0 +1,176 @@
+// src/components/products/PriceHistoryPanel.jsx
+import { useState, useEffect } from 'react';
+import { useAuth }           from '../../hooks/useAuth';
+import { getPriceHistory }   from '../../services/priceHistService';
+import AddPriceEntryForm     from './AddPriceEntryForm';
+
+/**
+ * @param {string}  prodcode  - The product whose price history to show
+ * @param {boolean} isOpen    - Controlled by parent (ProductsPage)
+ * @param {Function} onClose  - Called when user collapses the panel
+ */
+export default function PriceHistoryPanel({ prodcode, isOpen}) {
+  const { currentUser } = useAuth();
+
+  const [history,  setHistory]  = useState([]);
+  const [loading,  setLoading]  = useState(false);
+  const [error,    setError]    = useState('');
+
+  // Stamp visibility: ADMIN sees pricehist stamps; SUPERADMIN sees all; USER never
+  const showStamp = ['ADMIN', 'SUPERADMIN'].includes(currentUser?.user_type);
+
+  // Fetch when panel opens
+  useEffect(() => {
+    if (!isOpen || !prodcode) return;
+
+    let cancelled = false;
+
+    (async () => {
+      setLoading(() => true);
+      setError(() => '');
+
+      const { data, error: fetchError } = await getPriceHistory(prodcode);
+
+      if (cancelled) return;
+
+      if (fetchError) {
+        setError(() => 'Failed to load price history.');
+        setLoading(() => false);
+        return;
+      }
+
+      setHistory(() => data);
+      setLoading(() => false);
+    })();
+
+    return () => { cancelled = true; };
+  }, [isOpen, prodcode]);
+
+  // Re-fetch after a new price entry is added
+  async function handlePriceAdded() {
+    setLoading(() => true);
+    setError(() => '');
+
+    const { data, error: fetchError } = await getPriceHistory(prodcode);
+
+    if (fetchError) {
+      setError(() => 'Failed to load price history.');
+      setLoading(() => false);
+      return;
+    }
+
+    setHistory(() => data);
+    setLoading(() => false);
+  }
+
+  if (!isOpen) return null;
+
+  // The most recent entry is the first in the list (ordered by effdate DESC)
+  const currentEntryDate = history[0]?.effdate;
+
+  function formatPrice(p) {
+    return `₱ ${Number(p).toLocaleString('en-PH', { minimumFractionDigits: 2 })}`;
+  }
+
+  function formatDate(d) {
+    return new Date(d).toLocaleDateString('en-PH', {
+      year: 'numeric', month: 'short', day: 'numeric'
+    });
+  }
+
+  return (
+    <div className="bg-blue-50 border border-blue-100 p-4">
+
+      {/* Panel header */}
+      <div className="flex items-center mb-3">
+        <div>
+          <span className="text-sm font-semibold text-blue-800">
+            Price History
+          </span>
+          <span className="ml-2 text-xs text-blue-500 font-mono">{prodcode}</span>
+        </div>
+      </div>
+
+      {/* Loading */}
+      {loading && (
+        <div className="flex items-center justify-center py-6">
+          <div className="w-6 h-6 border-3 border-blue-500 border-t-transparent rounded-full animate-spin" />
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <div className="rounded-lg bg-red-50 border border-red-200 px-3 py-2 text-xs text-red-700 mb-3">
+          {error}
+          <button onClick={handlePriceAdded} className="ml-2 underline">Retry</button>
+        </div>
+      )}
+
+      {/* Empty */}
+      {!loading && !error && history.length === 0 && (
+        <p className="text-xs text-blue-400 text-center py-4">
+          No price history recorded yet. Add the first price entry below.
+        </p>
+      )}
+
+      {/* History table */}
+      {!loading && !error && history.length > 0 && (
+        <div className="overflow-x-auto mb-4">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-blue-600 font-semibold">
+                <th className="text-left pb-2 pr-4">Effective Date</th>
+                <th className="text-right pb-2 pr-4">Unit Price</th>
+                {/* Stamp — absent from DOM for USER */}
+                {showStamp && (
+                  <th className="text-left pb-2 pr-4">Stamp</th>
+                )}
+                <th className="text-left pb-2">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {history.map((entry) => {
+                const isCurrent = entry.effdate === currentEntryDate;
+                return (
+                  <tr
+                    key={`${entry.prodcode}-${entry.effdate}`}
+                    className={isCurrent ? 'text-blue-900 font-medium' : 'text-blue-700'}
+                  >
+                    <td className="py-1 pr-4 font-mono">
+                      {formatDate(entry.effdate)}
+                    </td>
+                    <td className="py-1 pr-4 tabular-nums text-right">
+                      {formatPrice(entry.unitprice)}
+                    </td>
+                    {/* Stamp — absent from DOM for USER (project guide Section 9.3) */}
+                    {showStamp && (
+                      <td className="py-1 pr-4 font-mono text-blue-400">
+                        {entry.stamp ?? '—'}
+                      </td>
+                    )}
+                    <td className="py-1">
+                      {isCurrent ? (
+                        <span className="inline-block bg-blue-600 text-white text-xs px-2 py-0.5 rounded-full">
+                          CURRENT
+                        </span>
+                      ) : (
+                        <span className="text-blue-300 text-xs">—</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Add Price Entry Form — always visible inside the open panel */}
+      <AddPriceEntryForm
+        prodcode={prodcode}
+        onSuccess={handlePriceAdded}
+      />
+
+    </div>
+  );
+}

--- a/src/pages/ProductsPage.jsx
+++ b/src/pages/ProductsPage.jsx
@@ -1,5 +1,6 @@
 // src/pages/ProductsPage.jsx
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, Fragment } from 'react';
+import PriceHistoryPanel        from '../components/products/PriceHistoryPanel';
 import { useAuth }              from '../hooks/useAuth';
 import { useRights }            from '../hooks/useRights';
 import { getProducts }          from '../services/productService';
@@ -7,6 +8,24 @@ import { getAllCurrentPrices }  from '../services/priceHistService';
 import AddProductModal          from '../components/products/AddProductModal';
 import EditProductModal         from '../components/products/EditProductModal';
 import SoftDeleteConfirmDialog  from '../components/products/SoftDeleteConfirmDialog';
+
+// ── SortTh moved outside component to avoid static-components lint error ──
+function SortTh({ field, label, sortField, sortDirection, onSort }) {
+  const active = sortField === field;
+  const icon   = sortDirection === 'asc' ? '↑' : '↓';
+  return (
+    <th
+      className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide cursor-pointer select-none hover:text-gray-700"
+      onClick={() => onSort(field)}
+    >
+      {label}{' '}
+      {active
+        ? <span className="text-blue-500">{icon}</span>
+        : <span className="text-gray-300">↕</span>
+      }
+    </th>
+  );
+}
 
 export default function ProductsPage() {
   const { currentUser } = useAuth();
@@ -27,12 +46,16 @@ export default function ProductsPage() {
   const [showAddModal,     setShowAddModal]     = useState(false);
   const [showEditModal,    setShowEditModal]    = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [expandedProdcode, setExpandedProdcode] = useState(null);
+
+  function handleTogglePriceHistory(prodcode) {
+    setExpandedProdcode(prev => prev === prodcode ? null : prodcode);
+  }
 
   // ── Rights (project guide Section 2.2) ───────────────────────
   const canAdd    = rights?.PRD_ADD  === 1;
   const canEdit   = rights?.PRD_EDIT === 1;
   const canDelete = rights?.PRD_DEL  === 1;
-  // Stamp: ADMIN sees product + priceHist stamps; SUPERADMIN sees all; USER sees none
   const showStamp = ['ADMIN', 'SUPERADMIN'].includes(userType);
 
   // ── Fetch ─────────────────────────────────────────────────────
@@ -57,7 +80,36 @@ export default function ProductsPage() {
     setLoading(false);
   }
 
-  useEffect(() => { fetchData(); }, [userType]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Cleanup flag prevents setState on unmounted component
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      setError('');
+
+      const [prodResult, priceResult] = await Promise.all([
+        getProducts(userType),
+        getAllCurrentPrices(),
+      ]);
+
+      if (cancelled) return;
+
+      if (prodResult.error) {
+        setError('Failed to load products. Please try again.');
+        setLoading(false);
+        return;
+      }
+
+      setProducts(prodResult.data);
+      const map = new Map((priceResult.data ?? []).map(p => [p.prodcode, p]));
+      setPrices(map);
+      setLoading(false);
+    }
+
+    load();
+    return () => { cancelled = true; };
+  }, [userType]);
 
   function handleDataChange() { fetchData(); }
 
@@ -93,24 +145,6 @@ export default function ProductsPage() {
     }
   }
 
-  // ── Helpers ───────────────────────────────────────────────────
-  function SortTh({ field, label }) {
-    const active = sortField === field;
-    const icon   = sortDirection === 'asc' ? '↑' : '↓';
-    return (
-      <th
-        className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide cursor-pointer select-none hover:text-gray-700"
-        onClick={() => handleSort(field)}
-      >
-        {label}{' '}
-        {active
-          ? <span className="text-blue-500">{icon}</span>
-          : <span className="text-gray-300">↕</span>
-        }
-      </th>
-    );
-  }
-
   function formatPrice(prodcode) {
     const p = prices.get(prodcode);
     if (!p?.unitprice) return '—';
@@ -132,7 +166,6 @@ export default function ProductsPage() {
           )}
         </div>
 
-        {/* Add button — absent from DOM when PRD_ADD = 0 */}
         {canAdd && (
           <button
             onClick={() => setShowAddModal(true)}
@@ -192,11 +225,10 @@ export default function ProductsPage() {
             <table className="w-full text-sm">
               <thead className="bg-gray-50 border-b border-gray-200">
                 <tr>
-                  <SortTh field="prodcode"    label="Code" />
-                  <SortTh field="description" label="Description" />
-                  <SortTh field="unit"        label="Unit" />
-                  <SortTh field="unitprice"   label="Current Price" />
-                  {/* Stamp column — absent from DOM for USER (project guide Section 9.3) */}
+                  <SortTh field="prodcode"    label="Code"          sortField={sortField} sortDirection={sortDirection} onSort={handleSort} />
+                  <SortTh field="description" label="Description"   sortField={sortField} sortDirection={sortDirection} onSort={handleSort} />
+                  <SortTh field="unit"        label="Unit"          sortField={sortField} sortDirection={sortDirection} onSort={handleSort} />
+                  <SortTh field="unitprice"   label="Current Price" sortField={sortField} sortDirection={sortDirection} onSort={handleSort} />
                   {showStamp && (
                     <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
                       Stamp
@@ -212,50 +244,51 @@ export default function ProductsPage() {
 
               <tbody className="divide-y divide-gray-100">
                 {displayed.map(product => (
-                  <tr key={product.prodcode} className="hover:bg-gray-50 transition-colors">
-                    <td className="px-4 py-3 font-mono font-medium text-gray-800">
-                      {product.prodcode}
-                    </td>
-                    <td className="px-4 py-3 text-gray-700">
-                      {product.description}
-                    </td>
-                    <td className="px-4 py-3 text-gray-500">
-                      {product.unit}
-                    </td>
-                    <td className="px-4 py-3 text-gray-700 tabular-nums">
-                      {formatPrice(product.prodcode)}
-                    </td>
+                  <Fragment key={product.prodcode}>
 
-                    {/* Stamp — absent from DOM for USER */}
-                    {showStamp && (
-                      <td className="px-4 py-3 text-xs text-gray-400 font-mono">
-                        {product.stamp ?? '—'}
+                    {/* Product row */}
+                    <tr className="hover:bg-gray-50 transition-colors">
+                      <td className="px-4 py-3 font-mono font-medium text-gray-800">
+                        {product.prodcode}
                       </td>
-                    )}
+                      <td className="px-4 py-3 text-gray-700">{product.description}</td>
+                      <td className="px-4 py-3 text-gray-500">{product.unit}</td>
+                      <td className="px-4 py-3 text-gray-700 tabular-nums">
+                        {formatPrice(product.prodcode)}
+                      </td>
 
-                    {/* Actions — absent from DOM when no write rights */}
-                    {(canEdit || canDelete) && (
+                      {showStamp && (
+                        <td className="px-4 py-3 text-xs text-gray-400 font-mono">
+                          {product.stamp ?? '—'}
+                        </td>
+                      )}
+
+                      {/* Actions column */}
                       <td className="px-4 py-3">
                         <div className="flex items-center justify-end gap-3">
-                          {/* Edit — absent when PRD_EDIT = 0 */}
+                          {/* Price History toggle — visible to all authenticated users */}
+                          <button
+                            onClick={() => handleTogglePriceHistory(product.prodcode)}
+                            className={`text-xs font-medium transition-colors ${
+                              expandedProdcode === product.prodcode
+                                ? 'text-blue-700 underline'
+                                : 'text-blue-500 hover:text-blue-700'
+                            }`}
+                          >
+                            {expandedProdcode === product.prodcode ? 'Hide ▲' : 'Price History ▼'}
+                          </button>
+
                           {canEdit && (
                             <button
-                              onClick={() => {
-                                setSelectedProduct(product);
-                                setShowEditModal(true);
-                              }}
+                              onClick={() => { setSelectedProduct(product); setShowEditModal(true); }}
                               className="text-xs font-medium text-blue-600 hover:text-blue-800"
                             >
                               Edit
                             </button>
                           )}
-                          {/* Delete — absent when PRD_DEL = 0 (SUPERADMIN only) */}
                           {canDelete && (
                             <button
-                              onClick={() => {
-                                setSelectedProduct(product);
-                                setShowDeleteDialog(true);
-                              }}
+                              onClick={() => { setSelectedProduct(product); setShowDeleteDialog(true); }}
                               className="text-xs font-medium text-red-500 hover:text-red-700"
                             >
                               Delete
@@ -263,8 +296,27 @@ export default function ProductsPage() {
                           )}
                         </div>
                       </td>
+                    </tr>
+
+                    {/* Price History Panel row — spans all columns */}
+                    {expandedProdcode === product.prodcode && (
+                      <tr>
+                        <td
+                          colSpan={
+                            4 + (showStamp ? 1 : 0) + ((canEdit || canDelete) ? 1 : 0)
+                          }
+                          className="p-0"
+                        >
+                          <PriceHistoryPanel
+                            prodcode={product.prodcode}
+                            isOpen={true}
+                            onClose={() => setExpandedProdcode(null)}
+                          />
+                        </td>
+                      </tr>
                     )}
-                  </tr>
+
+                  </Fragment>
                 ))}
               </tbody>
             </table>
@@ -272,7 +324,7 @@ export default function ProductsPage() {
         </div>
       )}
 
-      {/* Modals — controlled by state, rendered outside table */}
+      {/* Modals */}
       {showAddModal && canAdd && (
         <AddProductModal
           onClose={() => setShowAddModal(false)}


### PR DESCRIPTION
## What changed
- src/components/products/PriceHistoryPanel.jsx
    Expandable panel per product row showing all pricehist entries ordered newest first
    Most recent entry labeled CURRENT with blue badge
    Stamp column absent from DOM for USER accounts
    Fetches on open; re-fetches after AddPriceEntryForm succeeds
    Only one panel open at a time (expandedProdcode state in parent)
- src/components/products/AddPriceEntryForm.jsx
    Inline form inside panel for adding price entries
    Validates: effdate required + not future; unitprice > 0
    Calls addPriceEntry(); resets fields on success; inline error messages
- src/pages/ProductsPage.jsx updated
    Added expandedProdcode state and handleTogglePriceHistory()
    Each product row has "Price History ▼ / Hide ▲" toggle
    Panel row spans all columns; colSpan computed dynamically

## How to test
SUPERADMIN: expand panel → history + stamp shown → CURRENT badge → add entry → refreshes
USER: expand panel → stamp absent from DOM → add entry → works
Add price 0 → "must be greater than 0" error
Add future date → "cannot be in the future" error
Expand second panel → first collapses automatically

<img width="1511" height="527" alt="Screenshot 2026-04-18 101229" src="https://github.com/user-attachments/assets/7ae25c70-57a0-4e11-b57a-1c19c3d447c3" />
<img width="1484" height="439" alt="Screenshot 2026-04-18 101336" src="https://github.com/user-attachments/assets/e26d8f18-36ff-484c-8d86-a9c338dc06d6" />
<img width="1004" height="480" alt="Screenshot 2026-04-18 101406" src="https://github.com/user-attachments/assets/397f573f-0be9-46e0-a768-762de8ce822e" />
<img width="1492" height="389" alt="Screenshot 2026-04-18 101431" src="https://github.com/user-attachments/assets/cb763888-f821-433c-ad08-e89b584db133" />
<img width="1919" height="924" alt="Screenshot 2026-04-18 101650" src="https://github.com/user-attachments/assets/368b7a5b-2491-4fbd-9ebb-6ec24b872270" />
<img width="1918" height="909" alt="Screenshot 2026-04-18 101754" src="https://github.com/user-attachments/assets/7a942491-7b03-4110-8361-cc0a919c7a2c" />
<img width="1917" height="934" alt="Screenshot 2026-04-18 101855" src="https://github.com/user-attachments/assets/087b592a-aafe-4aba-aa06-7b60e12d33c3" />
<img width="1489" height="351" alt="Screenshot 2026-04-18 102221" src="https://github.com/user-attachments/assets/41c6c5c9-43a8-459e-bcbd-26a8efd6c066" />
