### PR TITLE
feat/rights-ui-gating — Button gating (Add/Edit/Delete) and stamp column visibility

### DIFF
--- a/src/components/products/AddProductModal.jsx
+++ b/src/components/products/AddProductModal.jsx
@@ -1,6 +1,6 @@
 // src/components/products/AddProductModal.jsx
+import { useProductRights } from '../../hooks/useProductRights';
 import { useState, useEffect } from 'react';
-import { useAuth }      from '../../hooks/useAuth';
 import { addProduct }   from '../../services/productService';
 
 const UNIT_OPTIONS = ['pc', 'ea', 'mtr', 'pkg', 'ltr'];
@@ -10,7 +10,10 @@ const UNIT_OPTIONS = ['pc', 'ea', 'mtr', 'pkg', 'ltr'];
  * @param {Function} onSuccess - Called after successful product creation
  */
 export default function AddProductModal({ onClose, onSuccess }) {
-  const { currentUser } = useAuth();
+  const { canAdd, rightsLoading } = useProductRights();
+
+if (rightsLoading) return null;
+if (!canAdd) return null;
 
   const [prodcode,    setProdcode]    = useState('');
   const [description, setDescription] = useState('');

--- a/src/components/products/EditProductModal.jsx
+++ b/src/components/products/EditProductModal.jsx
@@ -1,6 +1,6 @@
 // src/components/products/EditProductModal.jsx
+import { useProductRights } from '../../hooks/useProductRights';
 import { useState, useEffect } from 'react';
-import { useAuth }        from '../../hooks/useAuth';
 import { updateProduct }  from '../../services/productService';
 
 const UNIT_OPTIONS = ['pc', 'ea', 'mtr', 'pkg', 'ltr'];
@@ -11,7 +11,10 @@ const UNIT_OPTIONS = ['pc', 'ea', 'mtr', 'pkg', 'ltr'];
  * @param {Function} onSuccess
  */
 export default function EditProductModal({ product, onClose, onSuccess }) {
-  const { currentUser } = useAuth();
+  const { canEdit, rightsLoading } = useProductRights();
+
+if (rightsLoading) return null;
+if (!canEdit) return null;
 
   const [description, setDescription] = useState(product?.description ?? '');
   const [unit,        setUnit]        = useState(product?.unit ?? 'pc');

--- a/src/components/products/PriceHistoryPanel.jsx
+++ b/src/components/products/PriceHistoryPanel.jsx
@@ -1,6 +1,7 @@
 // src/components/products/PriceHistoryPanel.jsx
+import { useProductRights } from '../../hooks/useProductRights';
 import { useState, useEffect } from 'react';
-import { useAuth }           from '../../hooks/useAuth';
+
 import { getPriceHistory }   from '../../services/priceHistService';
 import AddPriceEntryForm     from './AddPriceEntryForm';
 
@@ -10,14 +11,14 @@ import AddPriceEntryForm     from './AddPriceEntryForm';
  * @param {Function} onClose  - Called when user collapses the panel
  */
 export default function PriceHistoryPanel({ prodcode, isOpen}) {
-  const { currentUser } = useAuth();
+
 
   const [history,  setHistory]  = useState([]);
   const [loading,  setLoading]  = useState(false);
   const [error,    setError]    = useState('');
 
   // Stamp visibility: ADMIN sees pricehist stamps; SUPERADMIN sees all; USER never
-  const showStamp = ['ADMIN', 'SUPERADMIN'].includes(currentUser?.user_type);
+  const { showStamp } = useProductRights();
 
   // Fetch when panel opens
   useEffect(() => {

--- a/src/components/products/SoftDeleteConfirmDialog.jsx
+++ b/src/components/products/SoftDeleteConfirmDialog.jsx
@@ -1,6 +1,6 @@
 // src/components/products/SoftDeleteConfirmDialog.jsx
+import { useProductRights } from '../../hooks/useProductRights';
 import { useState, useEffect } from 'react';
-import { useAuth }             from '../../hooks/useAuth';
 import { softDeleteProduct }   from '../../services/productService';
 
 /**
@@ -9,7 +9,10 @@ import { softDeleteProduct }   from '../../services/productService';
  * @param {Function} onSuccess
  */
 export default function SoftDeleteConfirmDialog({ product, onClose, onSuccess }) {
-  const { currentUser } = useAuth();
+  const { canDelete, rightsLoading } = useProductRights();
+
+if (rightsLoading) return null;
+if (!canDelete) return null;
   const [loading, setLoading] = useState(false);
   const [error,   setError]   = useState('');
 

--- a/src/hooks/useProductRights.js
+++ b/src/hooks/useProductRights.js
@@ -1,0 +1,38 @@
+// src/hooks/useProductRights.js
+// Single hook for all product-related rights and display gates.
+// Components import this instead of calling useAuth() + useRights() separately.
+//
+// Usage:
+//   import { useProductRights } from '../hooks/useProductRights';
+//   const { canAdd, canEdit, canDelete, showStamp, userType, rightsLoading } = useProductRights();
+
+import { useAuth }   from './useAuth';
+import { useRights } from './useRights';
+
+export function useProductRights() {
+  const { currentUser }            = useAuth();
+  const { rights, rightsLoading }  = useRights();
+
+  const userType = currentUser?.user_type ?? 'USER';
+
+  return {
+    // ── Rights-based gates (sourced from UserModule_Rights via UserRightsContext) ──
+    // Each is true only when the DB-backed right_value = 1 for this user
+    canAdd:    rights.PRD_ADD  === 1,
+    canEdit:   rights.PRD_EDIT === 1,
+    canDelete: rights.PRD_DEL  === 1,   // SUPERADMIN only per rights matrix
+
+    // ── Stamp visibility (display rule — project guide Section 2.3) ──
+    // Not a right — gated by user_type, not UserModule_Rights
+    // SUPERADMIN: sees stamp on all tables
+    // ADMIN: sees stamp on product and priceHist tables
+    // USER: never sees stamp anywhere
+    showStamp: ['ADMIN', 'SUPERADMIN'].includes(userType),
+
+    // ── Raw values available for any edge case ──
+    userType,
+    currentUser,
+    rightsLoading,
+    rights,
+  };
+}

--- a/src/pages/ProductsPage.jsx
+++ b/src/pages/ProductsPage.jsx
@@ -1,8 +1,8 @@
 // src/pages/ProductsPage.jsx
+import { useProductRights } from '../hooks/useProductRights';
 import { useState, useEffect, useMemo, Fragment } from 'react';
 import PriceHistoryPanel        from '../components/products/PriceHistoryPanel';
-import { useAuth }              from '../hooks/useAuth';
-import { useRights }            from '../hooks/useRights';
+
 import { getProducts }          from '../services/productService';
 import { getAllCurrentPrices }  from '../services/priceHistService';
 import AddProductModal          from '../components/products/AddProductModal';
@@ -28,9 +28,7 @@ function SortTh({ field, label, sortField, sortDirection, onSort }) {
 }
 
 export default function ProductsPage() {
-  const { currentUser } = useAuth();
-  const { rights }      = useRights();
-  const userType        = currentUser?.user_type ?? 'USER';
+  
 
   // ── Data ─────────────────────────────────────────────────────
   const [products,  setProducts]  = useState([]);
@@ -52,12 +50,7 @@ export default function ProductsPage() {
     setExpandedProdcode(prev => prev === prodcode ? null : prodcode);
   }
 
-  // ── Rights (project guide Section 2.2) ───────────────────────
-  const canAdd    = rights?.PRD_ADD  === 1;
-  const canEdit   = rights?.PRD_EDIT === 1;
-  const canDelete = rights?.PRD_DEL  === 1;
-  const showStamp = ['ADMIN', 'SUPERADMIN'].includes(userType);
-
+ const { canAdd, canEdit, canDelete, showStamp, currentUser, userType } = useProductRights();
   // ── Fetch ─────────────────────────────────────────────────────
   async function fetchData() {
     setLoading(true);


### PR DESCRIPTION
## What changed
- src/hooks/useProductRights.js (new)
  Composes useAuth() + useRights() into a single hook.
  Exposes: canAdd, canEdit, canDelete (rights-based), showStamp (user_type-based),
  userType, currentUser, rightsLoading, rights.

- src/pages/ProductsPage.jsx (updated)
  Replaced inline useAuth() + useRights() with useProductRights().
  All gating logic unchanged — DOM-absent conditional rendering preserved.

- src/components/products/PriceHistoryPanel.jsx (updated)
  Replaced inline useAuth() stamp gate with useProductRights().showStamp.

- src/components/products/AddProductModal.jsx (updated)
  Added: if (rightsLoading) return null; if (!canAdd) return null;

- src/components/products/EditProductModal.jsx (updated)
  Added: if (rightsLoading) return null; if (!canEdit) return null;

- src/components/products/SoftDeleteConfirmDialog.jsx (updated)
  Added: if (rightsLoading) return null; if (!canDelete) return null;

## Gating rules enforced
Add button:      DOM-absent when PRD_ADD = 0
Edit button:     DOM-absent per row when PRD_EDIT = 0
Delete button:   DOM-absent per row when PRD_DEL = 0 (SUPERADMIN only)
Stamp (product): <th> and <td> absent from DOM for USER
Stamp (price):   <th> and <td> absent from DOM for USER

## How to test
USER: inspect DOM → no Stamp <th>, no Delete <button> anywhere
ADMIN: inspect DOM → Stamp <th> present, Delete <button> absent
SUPERADMIN: all elements present