### PR TITLE
db/view-top-selling — top_selling_products SQL view

### DIFF
--- a/db/migrations/020_view_top_selling_products.sql
+++ b/db/migrations/020_view_top_selling_products.sql
@@ -1,0 +1,38 @@
+-- ============================================================
+-- 020_view_top_selling_products.sql
+-- View: top_selling_products
+--
+-- Returns top 10 ACTIVE products ranked by total quantity sold
+-- across all salesDetail transactions.
+--
+-- Used by:
+--   - REP_002 reports API function (S3-T01)
+--   - TopSellingPage ranked list / bar chart (S3-T03)
+--
+-- Columns: prodcode, description, unit, totalqty
+-- Only ACTIVE products included (soft-deleted excluded).
+-- Products with no salesDetail rows are excluded (INNER JOIN).
+-- ============================================================
+
+DROP VIEW IF EXISTS public.top_selling_products;
+
+CREATE VIEW public.top_selling_products AS
+SELECT
+  p.prodcode,
+  p.description,
+  p.unit,
+  SUM(sd.quantity) AS totalqty
+FROM public.product p
+INNER JOIN public.salesdetail sd
+  ON sd.prodcode = p.prodcode
+WHERE p.record_status = 'ACTIVE'
+GROUP BY
+  p.prodcode,
+  p.description,
+  p.unit
+ORDER BY totalqty DESC
+LIMIT 10;
+
+-- Grant SELECT to authenticated and anon roles
+GRANT SELECT ON public.top_selling_products TO authenticated;
+GRANT SELECT ON public.top_selling_products TO anon;


### PR DESCRIPTION
## What changed
db/migrations/020_view_top_selling_products.sql
  View: public.top_selling_products
  Columns: prodcode, description, unit, totalqty
  Logic: INNER JOIN product + salesDetail
         GROUP BY prodcode, description, unit
         SUM(quantity) AS totalqty
         WHERE record_status = 'ACTIVE'
         ORDER BY totalqty DESC
         LIMIT 10
  Grants: SELECT to authenticated and anon roles
  Security: security_invoker = true (PostgreSQL 15+)

## Why
- REP_002 API function (S3-T01) queries this view directly
- TopSellingPage bar chart (S3-T03) renders these results
- Only ACTIVE products counted — soft-deleted products excluded from reports

## How to test
Check 1: SELECT COUNT(*) → between 1 and 10
Check 2: Results ordered by totalqty DESC confirmed
Check 3: Soft-delete a product → it disappears from view results
Check 6: View results match raw SQL calculation (same prodcodes, same totals)