### PR TITLE
feat/rights-superadmin-guard — SUPERADMIN row disabling in UserManagementPage

### DIFF
--- a/src/hooks/useSuperAdminGuard.js
+++ b/src/hooks/useSuperAdminGuard.js
@@ -1,0 +1,68 @@
+// src/hooks/useSuperAdminGuard.js
+// Centralised SUPERADMIN row protection for the Admin Module.
+// Provides a guard function and constants used by UserManagementPage
+// (and any future admin components that list users).
+//
+// Project guide Section 7.2:
+//   "Even if an ADMIN somehow bypasses the UI, the RLS policy at the
+//    database level will reject the UPDATE. Both layers must be in place."
+//
+// Usage:
+//   import { useSuperAdminGuard } from '../hooks/useSuperAdminGuard';
+//   const { isProtectedRow, TOOLTIP_TEXT } = useSuperAdminGuard();
+//   <button disabled={isProtectedRow(user)} title={isProtectedRow(user) ? TOOLTIP_TEXT : ''}>
+//     Activate
+//   </button>
+
+// The exact tooltip text required by the project guide and UI spec
+export const SUPERADMIN_TOOLTIP = 'SUPERADMIN accounts cannot be modified';
+
+/**
+ * Returns guard utilities for SUPERADMIN row protection.
+ * No context dependencies — pure utility, no hook state.
+ */
+export function useSuperAdminGuard() {
+  /**
+   * Returns true if the target user row should have all action buttons disabled.
+   * A row is protected if the user's user_type is 'SUPERADMIN'.
+   * This applies regardless of who is currently signed in.
+   *
+   * @param {object} targetUser - A user row from getAllUsers()
+   * @param {string} targetUser.user_type - The role of the target user
+   * @returns {boolean}
+   */
+  function isProtectedRow(targetUser) {
+    return targetUser?.user_type === 'SUPERADMIN';
+  }
+
+  /**
+   * Returns the tooltip text for disabled buttons on protected rows.
+   * Returns an empty string for unprotected rows (no tooltip shown).
+   *
+   * @param {object} targetUser
+   * @returns {string}
+   */
+  function getTooltip(targetUser) {
+    return isProtectedRow(targetUser) ? SUPERADMIN_TOOLTIP : '';
+  }
+
+  /**
+   * Returns the className modifier for a protected row's container <tr>.
+   * Protected rows get a distinct visual treatment.
+   *
+   * @param {object} targetUser
+   * @returns {string} Tailwind classes to apply
+   */
+  function getRowClass(targetUser) {
+    return isProtectedRow(targetUser)
+      ? 'bg-purple-50'
+      : 'hover:bg-gray-50 transition-colors';
+  }
+
+  return {
+    isProtectedRow,
+    getTooltip,
+    getRowClass,
+    TOOLTIP_TEXT: SUPERADMIN_TOOLTIP,
+  };
+}

--- a/src/pages/UserManagementPage.jsx
+++ b/src/pages/UserManagementPage.jsx
@@ -7,6 +7,7 @@ import { useState, useEffect } from 'react';
 import { useAuth }       from '../hooks/useAuth';
 import { useRights }     from '../hooks/useRights';
 import { getAllUsers, activateUser, deactivateUser } from '../services/userService';
+import { useSuperAdminGuard } from '../hooks/useSuperAdminGuard';
 
 // Badge component for record_status
 function StatusBadge({ status }) {
@@ -71,10 +72,10 @@ export default function UserManagementPage() {
 
   // SUPERADMIN protection check — project guide Section 7.2
   // All buttons on SUPERADMIN rows are disabled regardless of actor.
-  const isSuperAdmin = (targetUser) => targetUser.user_type === 'SUPERADMIN';
+  const { isProtectedRow, getTooltip, getRowClass } = useSuperAdminGuard();
 
   async function handleActivate(user) {
-    if (isSuperAdmin(user)) return; // safety guard — should never reach here due to disabled button
+    if (isProtectedRow(user)) return;
 
     setActionError('');
     setSuccessMsg('');
@@ -102,7 +103,7 @@ export default function UserManagementPage() {
   }
 
   async function handleDeactivate(user) {
-    if (isSuperAdmin(user)) return;
+    if (isProtectedRow(user)) return;
 
     setActionError('');
     setSuccessMsg('');
@@ -203,7 +204,7 @@ export default function UserManagementPage() {
 
               <tbody className="divide-y divide-gray-100">
                 {sorted.map(user => {
-                  const superadminRow = isSuperAdmin(user);
+                  const superadminRow = isProtectedRow(user);
                   const isCurrentUser = user.userid === currentUser?.userid;
                   const isUpdating    = actionId === user.userid;
                   const isActive      = user.record_status === 'ACTIVE';
@@ -211,7 +212,7 @@ export default function UserManagementPage() {
                   return (
                     <tr
                       key={user.userid}
-                      className={`transition-colors ${superadminRow ? 'bg-purple-50' : 'hover:bg-gray-50'}`}
+                      className={getRowClass(user)}
                     >
                       {/* Username */}
                       <td className="px-4 py-3">
@@ -250,7 +251,7 @@ export default function UserManagementPage() {
                           {/* Activate button */}
                           {/* Disabled for SUPERADMIN rows (project guide Section 7.2) */}
                           <div
-                            title={superadminRow ? 'SUPERADMIN accounts cannot be modified' : ''}
+                            title={getTooltip(user)}
                             className="inline-block"
                           >
                             <button
@@ -268,7 +269,7 @@ export default function UserManagementPage() {
 
                           {/* Deactivate button */}
                           <div
-                            title={superadminRow ? 'SUPERADMIN accounts cannot be modified' : ''}
+                            title={getTooltip(user)}
                             className="inline-block"
                           >
                             <button


### PR DESCRIPTION
## What changed
- src/hooks/useSuperAdminGuard.js (new)
  Exports: isProtectedRow(targetUser) → boolean
           getTooltip(targetUser) → string
           getRowClass(targetUser) → Tailwind classes
           TOOLTIP_TEXT = 'SUPERADMIN accounts cannot be modified'

- src/pages/UserManagementPage.jsx (updated)
  Removed: inline isSuperAdmin() function
  Added: useSuperAdminGuard() hook from import
  All three usages (handleActivate guard, handleDeactivate guard, row rendering)
  now read from the hook — single source of truth for SUPERADMIN protection.

## Verification
UI: SUPERADMIN rows — Activate and Deactivate both disabled
Tooltip: "SUPERADMIN accounts cannot be modified" on hover (native title attr on wrapper div)
ADMIN viewing the page: same protection applies — viewer's role doesn't affect target protection
DB: ADMIN direct API deactivate(SUPERADMIN_UUID) → BLOCKED by RLS (S3-T07)

## How to test
Sign in as SUPERADMIN → /admin → hover over SUPERADMIN row buttons → tooltip appears
Sign in as ADMIN → /admin → SUPERADMIN row buttons still disabled (not actor-dependent)
DevTools inspect: button has disabled attr; wrapper div has correct title attr
Console: deactivateUser(SUPERADMIN_UUID) as ADMIN → RLS error returned