### PR TITLE
fix/stamp-visibility -- visibility rules across all tables via useStampVisibility hook

### DIFF
--- a/src/components/products/PriceHistoryPanel.jsx
+++ b/src/components/products/PriceHistoryPanel.jsx
@@ -1,7 +1,7 @@
 // src/components/products/PriceHistoryPanel.jsx
 import { useProductRights } from '../../hooks/useProductRights';
 import { useState, useEffect } from 'react';
-
+import { useStampVisibility } from '../../hooks/useStampVisibility';
 import { getPriceHistory }   from '../../services/priceHistService';
 import AddPriceEntryForm     from './AddPriceEntryForm';
 
@@ -18,7 +18,8 @@ export default function PriceHistoryPanel({ prodcode, isOpen}) {
   const [error,    setError]    = useState('');
 
   // Stamp visibility: ADMIN sees pricehist stamps; SUPERADMIN sees all; USER never
-  const { showStamp } = useProductRights();
+  //const { showStamp } = useProductRights();
+  const { showPriceHistStamp } = useStampVisibility();
 
   // Fetch when panel opens
   useEffect(() => {
@@ -123,7 +124,7 @@ export default function PriceHistoryPanel({ prodcode, isOpen}) {
                 <th className="text-left pb-2 pr-4">Effective Date</th>
                 <th className="text-right pb-2 pr-4">Unit Price</th>
                 {/* Stamp — absent from DOM for USER */}
-                {showStamp && (
+                {showPriceHistStamp && (
                   <th className="text-left pb-2 pr-4">Stamp</th>
                 )}
                 <th className="text-left pb-2">Status</th>
@@ -144,7 +145,7 @@ export default function PriceHistoryPanel({ prodcode, isOpen}) {
                       {formatPrice(entry.unitprice)}
                     </td>
                     {/* Stamp — absent from DOM for USER (project guide Section 9.3) */}
-                    {showStamp && (
+                    {showPriceHistStamp && (
                       <td className="py-1 pr-4 font-mono text-blue-400">
                         {entry.stamp ?? '—'}
                       </td>

--- a/src/hooks/useProductRights.js
+++ b/src/hooks/useProductRights.js
@@ -8,10 +8,12 @@
 
 import { useAuth }   from './useAuth';
 import { useRights } from './useRights';
+import { useStampVisibility } from './useStampVisibility';
 
 export function useProductRights() {
   const { currentUser }            = useAuth();
   const { rights, rightsLoading }  = useRights();
+  const { showProductStamp } = useStampVisibility();
 
   const userType = currentUser?.user_type ?? 'USER';
 
@@ -27,7 +29,7 @@ export function useProductRights() {
     // SUPERADMIN: sees stamp on all tables
     // ADMIN: sees stamp on product and priceHist tables
     // USER: never sees stamp anywhere
-    showStamp: ['ADMIN', 'SUPERADMIN'].includes(userType),
+    showStamp: showProductStamp,
 
     // ── Raw values available for any edge case ──
     userType,

--- a/src/hooks/useStampVisibility.js
+++ b/src/hooks/useStampVisibility.js
@@ -1,0 +1,49 @@
+// src/hooks/useStampVisibility.js
+// Centralised stamp visibility hook — project guide Section 2.3.
+//
+// Stamp visibility rules:
+//   SUPERADMIN: stamp visible on ALL tables (product, priceHist, user, deleted items)
+//   ADMIN:      stamp visible on product and priceHist tables ONLY
+//   USER:       stamp NEVER visible on any table
+//
+// Each flag is a boolean. Components use {flagName && <th>Stamp</th>}
+// for DOM-absent conditional rendering.
+//
+// Usage:
+//   import { useStampVisibility } from '../hooks/useStampVisibility';
+//   const { showProductStamp, showUserStamp } = useStampVisibility();
+
+import { useAuth } from './useAuth';
+
+export function useStampVisibility() {
+  const { currentUser } = useAuth();
+  const userType = currentUser?.user_type ?? 'USER';
+
+  const isSuperAdmin = userType === 'SUPERADMIN';
+  const isAdmin      = userType === 'ADMIN';
+  const isAdminOrAbove = isSuperAdmin || isAdmin;
+
+  return {
+    // product table (ProductsPage, DeletedItemsPage)
+    // Visible to: ADMIN and SUPERADMIN
+    showProductStamp: isAdminOrAbove,
+
+    // priceHist table (PriceHistoryPanel)
+    // Visible to: ADMIN and SUPERADMIN
+    showPriceHistStamp: isAdminOrAbove,
+
+    // Deleted Items page (product table — INACTIVE rows)
+    // Page is already role-gated to ADMIN/SUPERADMIN — stamp always shown here
+    showDeletedItemsStamp: isAdminOrAbove,
+
+    // user table (UserManagementPage)
+    // Project guide Section 2.3: ADMIN sees stamp on product/priceHist ONLY.
+    // Therefore ADMIN cannot see stamp on the user table.
+    showUserStamp: isSuperAdmin,
+
+    // Convenience — raw user type for any edge-case component logic
+    userType,
+    isSuperAdmin,
+    isAdminOrAbove,
+  };
+}

--- a/src/pages/DeletedItemsPage.jsx
+++ b/src/pages/DeletedItemsPage.jsx
@@ -3,9 +3,11 @@
 import { useState, useEffect } from 'react';
 import { useAuth }             from '../hooks/useAuth';
 import { getDeletedProducts, recoverProduct } from '../services/productService';
+import { useStampVisibility } from '../hooks/useStampVisibility';
 
 export default function DeletedItemsPage() {
   const { currentUser } = useAuth();
+  const { showDeletedItemsStamp } = useStampVisibility();
 
   const [products,     setProducts]     = useState([]);
   const [loading,      setLoading]      = useState(true);
@@ -134,20 +136,24 @@ export default function DeletedItemsPage() {
             <table className="w-full text-sm">
               <thead className="bg-gray-50 border-b border-gray-200">
                 <tr>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Product Code</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Description</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Unit</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Stamp</th>
-                  <th className="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wide">Action</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Code</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Description</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Unit</th>
+                  {showDeletedItemsStamp && (
+                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Stamp</th>
+                  )}
+                  <th className="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase">Actions</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">
                 {products.map(product => (
-                  <tr key={product.prodcode} className="hover:bg-gray-50 transition-colors">
-                    <td className="px-4 py-3 font-mono font-medium text-gray-800">{product.prodcode}</td>
+                  <tr key={product.prodcode}>
+                    <td className="px-4 py-3 font-mono text-gray-800">{product.prodcode}</td>
                     <td className="px-4 py-3 text-gray-700">{product.description}</td>
                     <td className="px-4 py-3 text-gray-500">{product.unit}</td>
-                    <td className="px-4 py-3 text-xs text-gray-400 font-mono">{product.stamp ?? '—'}</td>
+                    {showDeletedItemsStamp && (
+                      <td className="px-4 py-3 text-xs text-gray-400">{product.stamp ?? '—'}</td>
+                    )}
                     <td className="px-4 py-3 text-right">
                       <button
                         onClick={() => handleRecover(product)}

--- a/src/pages/ProductsPage.jsx
+++ b/src/pages/ProductsPage.jsx
@@ -1,5 +1,6 @@
 // src/pages/ProductsPage.jsx
 import { useProductRights } from '../hooks/useProductRights';
+import { useStampVisibility } from '../hooks/useStampVisibility';
 import { useState, useEffect, useMemo, Fragment } from 'react';
 import PriceHistoryPanel        from '../components/products/PriceHistoryPanel';
 
@@ -28,7 +29,8 @@ function SortTh({ field, label, sortField, sortDirection, onSort }) {
 }
 
 export default function ProductsPage() {
-  
+  const { canAdd, canEdit, canDelete, showStamp, currentUser, userType } = useProductRights();
+  const { showProductStamp } = useStampVisibility();
 
   // ── Data ─────────────────────────────────────────────────────
   const [products,  setProducts]  = useState([]);
@@ -50,7 +52,6 @@ export default function ProductsPage() {
     setExpandedProdcode(prev => prev === prodcode ? null : prodcode);
   }
 
- const { canAdd, canEdit, canDelete, showStamp, currentUser, userType } = useProductRights();
   // ── Fetch ─────────────────────────────────────────────────────
   async function fetchData() {
     setLoading(true);
@@ -222,7 +223,7 @@ export default function ProductsPage() {
                   <SortTh field="description" label="Description"   sortField={sortField} sortDirection={sortDirection} onSort={handleSort} />
                   <SortTh field="unit"        label="Unit"          sortField={sortField} sortDirection={sortDirection} onSort={handleSort} />
                   <SortTh field="unitprice"   label="Current Price" sortField={sortField} sortDirection={sortDirection} onSort={handleSort} />
-                  {showStamp && (
+                  {showProductStamp && (
                     <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
                       Stamp
                     </th>
@@ -250,7 +251,7 @@ export default function ProductsPage() {
                         {formatPrice(product.prodcode)}
                       </td>
 
-                      {showStamp && (
+                      {showProductStamp && (
                         <td className="px-4 py-3 text-xs text-gray-400 font-mono">
                           {product.stamp ?? '—'}
                         </td>
@@ -296,7 +297,7 @@ export default function ProductsPage() {
                       <tr>
                         <td
                           colSpan={
-                            4 + (showStamp ? 1 : 0) + ((canEdit || canDelete) ? 1 : 0)
+                            4 + (showProductStamp ? 1 : 0) + ((canEdit || canDelete) ? 1 : 0)
                           }
                           className="p-0"
                         >

--- a/src/pages/UserManagementPage.jsx
+++ b/src/pages/UserManagementPage.jsx
@@ -9,6 +9,7 @@ import { useRights }     from '../hooks/useRights';
 import { getAllUsers, activateUser, deactivateUser } from '../services/userService';
 import { useSuperAdminGuard } from '../hooks/useSuperAdminGuard';
 import { changeUserRole }  from '../services/userService';
+import { useStampVisibility } from '../hooks/useStampVisibility';
 import ChangeRoleModal     from '../components/admin/ChangeRoleModal';
 
 
@@ -45,6 +46,7 @@ function TypeBadge({ userType }) {
 export default function UserManagementPage() {
   const { currentUser }     = useAuth();
   const { canManageUsers }  = useRights();
+  const { showUserStamp } = useStampVisibility();
 
   const [users,      setUsers]      = useState([]);
   const [loading,    setLoading]    = useState(true);
@@ -227,11 +229,14 @@ export default function UserManagementPage() {
             <table className="w-full text-sm">
               <thead className="bg-gray-50 border-b border-gray-200">
                 <tr>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Username</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Email / ID</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Role</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Status</th>
-                  <th className="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wide">Actions</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Username</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Email / ID</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Role</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Status</th>
+                  {showUserStamp && (
+                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Stamp</th>
+                  )}
+                  <th className="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase">Actions</th>
                 </tr>
               </thead>
 
@@ -276,6 +281,13 @@ export default function UserManagementPage() {
                       <td className="px-4 py-3">
                         <StatusBadge status={user.record_status} />
                       </td>
+                      {showUserStamp && (
+                        <td className="px-4 py-3 text-xs text-gray-400 font-mono max-w-[200px]">
+                          <span className="block truncate" title={user.stamp ?? ''}>
+                            {user.stamp ?? '—'}
+                          </span>
+                        </td>
+                      )}
 
                       {/* Actions */}
                       <td className="px-4 py-3">

--- a/src/services/productService.js
+++ b/src/services/productService.js
@@ -190,7 +190,7 @@ export async function recoverProduct(prodcode, userId) {
 export async function getDeletedProducts() {
   const { data, error } = await supabase
     .from('product')
-    .select('prodcode, description, unit, stamp')
+    .select('prodcode, description, unit, record_status, stamp')  // ADD stamp
     .eq('record_status', 'INACTIVE')
     .order('prodcode');
 


### PR DESCRIPTION
## What changed
- src/hooks/useStampVisibility.js (new)
    showProductStamp: ADMIN and SUPERADMIN (product, deleted items)
    showPriceHistStamp: ADMIN and SUPERADMIN (priceHist panel)
    showDeletedItemsStamp: ADMIN and SUPERADMIN (always shown — page is role-gated)
    showUserStamp: SUPERADMIN ONLY (ADMIN excluded per project guide Section 2.3)

- src/hooks/useProductRights.js (updated)
    showStamp now delegates to useStampVisibility().showProductStamp

- src/pages/ProductsPage.jsx
    Migrated from useProductRights().showStamp → useStampVisibility().showProductStamp

- src/components/products/PriceHistoryPanel.jsx
    Migrated to useStampVisibility().showPriceHistStamp

- src/pages/DeletedItemsPage.jsx
    Stamp column added ({showDeletedItemsStamp && <th/><td/>})
    productService.getDeletedProducts() now includes stamp in SELECT

- src/pages/UserManagementPage.jsx
    Stamp column added ({showUserStamp && <th/><td/>})
    Stamp truncated to max-w-[200px] with title tooltip for long values

## DOM-absent verification
- USER /products: Stamp = 0 of 0 in DevTools
- ADMIN /admin: Stamp = 0 of 0 in DevTools (ADMIN cannot see user stamps)
- SUPERADMIN /admin: Stamp column present in DOM