### PR TITLE
fix/ui-enhancement-v1 -- Navbar, Sidebar, page headers fix

### DIFF
--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -2,6 +2,20 @@
 import { useNavigate } from 'react-router-dom';
 import { useAuth }     from '../../hooks/useAuth';
 
+// Generate avatar initials from a name or email
+function getInitials(name = '') {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+  return name.slice(0, 2).toUpperCase() || 'U';
+}
+
+// Role badge colour
+function roleBadgeClass(userType) {
+  if (userType === 'SUPERADMIN') return 'bg-purple-100 text-purple-700 border border-purple-200';
+  if (userType === 'ADMIN')      return 'bg-blue-100 text-blue-700 border border-blue-200';
+  return 'bg-gray-100 text-gray-600 border border-gray-200';
+}
+
 export default function Navbar() {
   const { currentUser, signOut } = useAuth();
   const navigate = useNavigate();
@@ -11,26 +25,86 @@ export default function Navbar() {
     navigate('/login', { replace: true });
   }
 
-  // Fallback chain: username → email → 'User'
   const displayName = currentUser
     ? (currentUser.username || currentUser.email || 'User')
     : '';
 
+  const userType = currentUser?.user_type ?? '';
+
   return (
-    <header className="h-14 bg-white border-b border-gray-200 flex items-center justify-between px-6 shrink-0">
+    <header className="h-14 bg-white border-b border-gray-200 flex items-center justify-between px-6 shrink-0 z-10">
 
-      <span className="text-base font-semibold text-gray-800 tracking-tight">
-        Hope PMS
-      </span>
+      {/* Left — Brand */}
+      <div className="flex items-center gap-3">
+        {/* Logo mark */}
+        <div className="w-7 h-7 rounded-lg bg-blue-600 flex items-center justify-center shrink-0">
+          <span className="text-white text-xs font-bold tracking-tight">H</span>
+        </div>
+        <span className="text-sm font-bold text-gray-800 tracking-tight">
+          HopePMS
+        </span>
+        {/* System status pill */}
+        <div className="hidden sm:flex items-center gap-1.5 ml-2 px-2.5 py-0.5 rounded-full bg-green-50 border border-green-200">
+          <span className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
+          <span className="text-xs text-green-600 font-medium">All systems operational</span>
+        </div>
+      </div>
 
-      <div className="flex items-center gap-4">
+      {/* Right — User area */}
+      <div className="flex items-center gap-3">
+
+        {/* Notification bell — placeholder */}
+        <button
+          aria-label="Notifications"
+          className="w-8 h-8 flex items-center justify-center rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors relative"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6 6 0 00-9.33-5 6 6 0 00-2.67 5v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+          </svg>
+        </button>
+
+        {/* Settings icon — placeholder */}
+        <button
+          aria-label="Settings"
+          className="w-8 h-8 flex items-center justify-center rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+        </button>
+
+        {/* Divider */}
+        <div className="w-px h-6 bg-gray-200" />
+
+        {/* User info */}
         {displayName && (
-          <span className="text-sm text-gray-600">{displayName}</span>
+          <div className="flex items-center gap-2.5">
+            {/* Avatar circle */}
+            <div className="w-8 h-8 rounded-full bg-blue-600 flex items-center justify-center shrink-0">
+              <span className="text-white text-xs font-semibold">
+                {getInitials(displayName)}
+              </span>
+            </div>
+            <div className="hidden sm:block">
+              <p className="text-sm font-medium text-gray-800 leading-tight">{displayName}</p>
+              {userType && (
+                <span className={`inline-flex items-center px-1.5 py-px rounded text-xs font-semibold ${roleBadgeClass(userType)}`}>
+                  {userType}
+                </span>
+              )}
+            </div>
+          </div>
         )}
+
+        {/* Logout */}
         <button
           onClick={handleLogout}
-          className="text-sm text-gray-500 hover:text-red-600 transition-colors"
+          className="hidden sm:flex items-center gap-1.5 text-xs text-gray-500 hover:text-red-600 transition-colors px-2 py-1.5 rounded-lg hover:bg-red-50"
         >
+          <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+          </svg>
           Logout
         </button>
       </div>

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,16 +1,25 @@
 // src/components/layout/Sidebar.jsx
-import { NavLink } from 'react-router-dom';
+import { NavLink, useNavigate } from 'react-router-dom';
 import { useAuth }   from '../../hooks/useAuth';
 import { useRights } from '../../hooks/useRights';
 
-const base     = 'flex items-center gap-2.5 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors';
-const active   = 'bg-blue-50 text-blue-700 border-l-4 border-blue-600 pl-3.5';
-const inactive = 'text-gray-600 hover:bg-gray-100 hover:text-gray-900';
+function getInitials(name = '') {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+  return name.slice(0, 2).toUpperCase() || 'U';
+}
+
+const base     = 'flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-150';
+const active   = 'bg-blue-600 text-white shadow-sm';
+const inactive = 'text-gray-500 hover:bg-gray-100 hover:text-gray-800';
 
 const linkClass = ({ isActive }) => `${base} ${isActive ? active : inactive}`;
 
+const bottomLink = 'flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-sm font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-800 transition-all duration-150';
+
 export default function Sidebar() {
-  const { currentUser } = useAuth();
+  const { currentUser, signOut } = useAuth();
+  const navigate = useNavigate();
   const {
     canViewReports,
     canViewTopSelling,
@@ -18,58 +27,141 @@ export default function Sidebar() {
   } = useRights();
 
   const userType       = currentUser?.user_type ?? 'USER';
+  const displayName    = currentUser?.username || currentUser?.email || 'User';
   const canViewDeleted = ['ADMIN', 'SUPERADMIN'].includes(userType);
-  const isAdminOrAbove = ['ADMIN', 'SUPERADMIN'].includes(userType);  // ← NEW
+  const isAdminOrAbove = ['ADMIN', 'SUPERADMIN'].includes(userType);
+
+  async function handleLogout() {
+    await signOut();
+    navigate('/login', { replace: true });
+  }
+
+  // Role badge style
+  const roleBadge = {
+    SUPERADMIN: 'bg-purple-100 text-purple-700',
+    ADMIN:      'bg-blue-100 text-blue-700',
+    USER:       'bg-gray-100 text-gray-500',
+  }[userType] ?? 'bg-gray-100 text-gray-500';
 
   return (
-    <aside className="w-56 bg-white border-r border-gray-200 flex flex-col py-4 shrink-0 h-full">
-      <nav className="flex flex-col gap-1 px-2">
+    <aside className="w-60 bg-white border-r border-gray-200 flex flex-col shrink-0 h-full">
 
+      {/* ── User profile block ── */}
+      <div className="px-4 py-5 border-b border-gray-100">
+        <div className="flex items-center gap-3">
+          {/* Avatar */}
+          <div className="w-9 h-9 rounded-full bg-blue-600 flex items-center justify-center shrink-0">
+            <span className="text-white text-sm font-bold">{getInitials(displayName)}</span>
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-semibold text-gray-800 truncate">{displayName}</p>
+            <span className={`inline-flex items-center px-1.5 py-px rounded text-xs font-semibold mt-0.5 ${roleBadge}`}>
+              {userType}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Navigation ── */}
+      <nav className="flex-1 overflow-y-auto px-3 py-3 space-y-0.5">
+
+        {/* Dashboard — ADMIN and SUPERADMIN only */}
         {isAdminOrAbove && (
-        <NavLink to="/dashboard" className={linkClass}>
-          🏠 Dashboard
-        </NavLink>
+          <NavLink to="/dashboard" className={linkClass}>
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
+            </svg>
+            Dashboard
+          </NavLink>
         )}
 
         {/* Products — always visible */}
         <NavLink to="/products" className={linkClass}>
-          📦 Products
+          <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+          </svg>
+          Products
         </NavLink>
 
         {/* Reports (REP_001) */}
         {canViewReports && (
           <NavLink to="/reports" end className={linkClass}>
-            📊 Reports
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+            </svg>
+            Reports
           </NavLink>
         )}
 
         {/* Top Selling (REP_002) — SUPERADMIN only */}
         {canViewTopSelling && (
           <NavLink to="/reports/top-selling" className={linkClass}>
-            🏆 Top Selling
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+            </svg>
+            Top Selling
           </NavLink>
+        )}
+
+        {/* Section divider — admin area */}
+        {(canViewDeleted || canManageUsers || isAdminOrAbove) && (
+          <div className="pt-3 pb-1">
+            <p className="px-3 text-xs font-semibold text-gray-400 uppercase tracking-widest">Admin</p>
+          </div>
         )}
 
         {/* Deleted Items — ADMIN and SUPERADMIN */}
         {canViewDeleted && (
           <NavLink to="/deleted-items" className={linkClass}>
-            🗑 Deleted Items
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+            Deleted Items
           </NavLink>
         )}
 
-        {/* Admin / User Management — ADM_USER = 1 */}
+        {/* User Management — ADM_USER = 1 */}
         {canManageUsers && (
           <NavLink to="/admin" className={linkClass}>
-            ⚙ Admin
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+            </svg>
+            User Management
           </NavLink>
         )}
 
-        {/* Activity Log — all authenticated users */}
-        <NavLink to="/activity-log" className={linkClass}>
-          📋 Activity Log
-        </NavLink>
+        {/* Activity Log — ADMIN and SUPERADMIN */}
+        {isAdminOrAbove && (
+          <NavLink to="/activity-log" className={linkClass}>
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+            </svg>
+            Activity Log
+          </NavLink>
+        )}
 
       </nav>
+
+      {/* ── Bottom: Settings + Logout ── */}
+      <div className="px-3 py-3 border-t border-gray-100 space-y-0.5">
+        <button className={bottomLink} onClick={() => {}}>
+          <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+          Settings
+        </button>
+        <button
+          onClick={handleLogout}
+          className="w-full flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-sm font-medium text-red-500 hover:bg-red-50 hover:text-red-600 transition-all duration-150"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+          </svg>
+          Logout
+        </button>
+      </div>
+
     </aside>
   );
 }

--- a/src/pages/ActivityLogPage.jsx
+++ b/src/pages/ActivityLogPage.jsx
@@ -72,14 +72,18 @@ export default function ActivityLogPage() {
 
       {/* Header */}
       <div className="mb-6">
-        <h2 className="text-xl font-bold text-gray-800">Activity Log</h2>
-        <p className="text-sm text-gray-500 mt-0.5">
-          {isSuperAdmin
-            ? 'All system activity across all users.'
-            : isAdmin
-            ? 'Your activity and all product updates across the system.'
-            : 'Product activity across the system.'}
-        </p>
+        <div className="flex items-start justify-between">
+         <div>
+          <h1 className="text-2xl font-bold text-gray-900">Activity Log</h1>
+          <p className="text-sm text-gray-500 mt-0.5">
+            {isSuperAdmin
+              ? 'All system activity across all users.'
+              : isAdmin
+              ? 'Your activity and all product updates across the system.'
+              : 'Product activity across the system.'}
+          </p>
+        </div>
+       </div>
       </div>
 
       {error   && <ErrorBanner message={error} onRetry={fetchLogs} />}

--- a/src/pages/DeletedItemsPage.jsx
+++ b/src/pages/DeletedItemsPage.jsx
@@ -84,11 +84,31 @@ export default function DeletedItemsPage() {
 
       {/* Header */}
       <div className="mb-6">
-        <h2 className="text-xl font-bold text-gray-800">Deleted Items</h2>
-        <p className="text-sm text-gray-500 mt-0.5">
-          Soft-deleted products. These are hidden from all users but not permanently removed.
-          Recover them to make them visible again.
+        {/* Breadcrumb */}
+        <p className="text-xs text-gray-400 font-medium mb-2">
+          Admin <span className="mx-1">›</span> Deleted Items
         </p>
+
+        <div className="flex items-start justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">Archived Products</h1>
+            <p className="text-sm text-gray-500 mt-1">
+              Recover items removed by SUPERADMIN. Review the audit trail before restoration.
+            </p>
+          </div>
+        </div>
+
+        {/* Info strip */}
+        <div className="mt-4 flex flex-wrap items-center gap-4">
+          {!loading && products.length > 0 && (
+            <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-red-50 border border-red-200 text-xs font-medium text-red-600">
+              <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+              {products.length} archived item{products.length !== 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
       </div>
 
       {/* Success flash */}
@@ -136,13 +156,13 @@ export default function DeletedItemsPage() {
             <table className="w-full text-sm">
               <thead className="bg-gray-50 border-b border-gray-200">
                 <tr>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Code</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Description</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Unit</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Product ID</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Item Details</th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Unit</th>
                   {showDeletedItemsStamp && (
-                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Stamp</th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">Audit Stamp</th>
                   )}
-                  <th className="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase">Actions</th>
+                  <th className="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wide">Operations</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -99,10 +99,20 @@ export default function LoginPage() {
 
   return (
     <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
-      <div className="w-full max-w-sm bg-white rounded-2xl shadow-md p-8 text-center">
+      <div className="w-full max-w-sm">
+      {/* Brand header above the card */}
+      <div className="text-center mb-6">
+        <div className="inline-flex items-center justify-center w-12 h-12 rounded-2xl bg-blue-600 shadow-lg mb-3">
+          <span className="text-white text-xl font-bold">H</span>
+        </div>
+        <h1 className="text-2xl font-bold text-gray-900">HopePMS</h1>
+        <p className="text-sm text-gray-500 mt-1">Hope, Inc. — Product Management System</p>
+      </div>
 
-        <h1 className="text-2xl font-bold text-gray-800 mb-1">Hope PMS</h1>
-        <p className="text-sm text-gray-500 mb-8">Sign in to continue</p>
+      {/* Card */}
+      <div className="bg-white rounded-2xl shadow-lg border border-gray-100 p-8">
+        <h2 className="text-base font-semibold text-gray-800 mb-1">Welcome back</h2>
+        <p className="text-sm text-gray-400 mb-6">Sign in with your Google account to continue.</p>
 
         {displayError && (
           <div className="mb-6 rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700 text-left">
@@ -117,17 +127,19 @@ export default function LoginPage() {
 
         <button
           onClick={handleGoogleSignIn}
-          className="w-full flex items-center justify-center gap-3 border border-gray-300 hover:bg-gray-50 text-gray-700 font-medium py-3 px-4 rounded-xl text-sm transition-colors"
-        >
+          className="w-full flex items-center justify-center gap-3 border border-gray-200 hover:border-gray-300 hover:bg-gray-50 text-gray-700 font-medium py-3 px-4 rounded-xl text-sm transition-all shadow-sm">
           <img src="/google-icon.svg" alt="" className="w-5 h-5" />
-          Sign in with Google
+          Continue with Google
         </button>
 
-        <p className="mt-6 text-xs text-gray-400">
-          New accounts require administrator activation after first sign-in.
-        </p>
-
-      </div>
+          <p className="mt-5 text-xs text-gray-400 text-center">
+            New registrations require administrator activation.
+          </p>
+          <p className="mt-5 text-center text-xs text-gray-300">
+        Hope, Inc. · New Era University · AY 2025–2026
+      </p>
     </div>
+   </div>
+  </div>
   );
 }

--- a/src/pages/ProductsPage.jsx
+++ b/src/pages/ProductsPage.jsx
@@ -150,25 +150,61 @@ export default function ProductsPage() {
     <div className="p-6">
 
       {/* Header */}
-      <div className="flex items-center justify-between mb-6">
+      <div className="mb-6">
+      {/* Page title row */}
+      <div className="flex items-start justify-between">
         <div>
-          <h2 className="text-xl font-bold text-gray-800">Products</h2>
-          {!loading && (
-            <p className="text-sm text-gray-400 mt-0.5">
-              {displayed.length} product{displayed.length !== 1 ? 's' : ''}
-            </p>
-          )}
+          <h1 className="text-2xl font-bold text-gray-900">Product Catalogue</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Overseeing current inventory lifecycles and pricing structures.
+          </p>
         </div>
-
         {canAdd && (
           <button
             onClick={() => setShowAddModal(true)}
-            className="bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+            className="flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold px-4 py-2.5 rounded-xl transition-colors shadow-sm"
           >
-            + Add Product
+            <span className="text-base leading-none">+</span>
+            Add Product
           </button>
         )}
       </div>
+
+      {/* Stats sub-bar — SUPERADMIN/ADMIN only */}
+      {!loading && displayed.length > 0 && (
+        <div className="mt-4 flex flex-wrap items-center gap-6">
+          <div>
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-widest">Total Stock</p>
+            <p className="text-2xl font-bold text-gray-800">
+              {displayed.length.toLocaleString()}
+            </p>
+          </div>
+          <div className="w-px h-10 bg-gray-200" />
+          <div>
+            <p className="text-xs font-semibold text-gray-400 uppercase tracking-widest">Live Price Records</p>
+            <p className="text-2xl font-bold text-gray-800">
+              {prices.size.toLocaleString()}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* SUPERADMIN soft-delete notice — US-15 / US-32 */}
+      {canDelete && (
+        <div className="mt-4 flex items-center gap-2 px-4 py-2.5 rounded-xl bg-amber-50 border border-amber-200 text-sm text-amber-700">
+          <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+          <span>Soft-delete is available to <strong>SUPERADMIN</strong> only.</span>
+          <span className="ml-auto flex items-center gap-1 text-xs font-semibold text-amber-600">
+            <svg xmlns="http://www.w3.org/2000/svg" className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
+            RESTRICTED
+          </span>
+        </div>
+      )}
+    </div>
 
       {/* Search */}
       <div className="mb-4">

--- a/src/pages/ReportsPage.jsx
+++ b/src/pages/ReportsPage.jsx
@@ -1,9 +1,14 @@
 // src/pages/ReportsPage.jsx
 export default function ReportsPage() {
   return (
-    <div>
-      <h2 className="text-xl font-semibold text-gray-800">Reports</h2>
-      <p className="text-sm text-gray-500 mt-1">Reports will appear here.</p>
+    <div className="mb-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Reports</h1>
+          <p className="text-sm text-gray-500 mt-1">Reports will appear here.</p>
+        </div>
+        {/* Action button if applicable */}
+      </div>
     </div>
   );
 }

--- a/src/pages/TopSellingPage.jsx
+++ b/src/pages/TopSellingPage.jsx
@@ -63,22 +63,23 @@ export default function TopSellingPage() {
     <div className="p-6">
 
       {/* Header */}
-      <div className="flex items-start justify-between mb-6">
+    <div className="mb-6">
+      <div className="flex items-start justify-between">
         <div>
-          <h2 className="text-xl font-bold text-gray-800">Top Selling Products</h2>
-          <p className="text-sm text-gray-500 mt-0.5">
-            Top 10 active products ranked by total quantity sold across all transactions.
-          </p>
+          <h1 className="text-2xl font-bold text-gray-900">Top Selling Products</h1>
+          <p className="text-sm text-gray-500 mt-1">Top 10 active products ranked by total quantity sold across all transactions.</p>
         </div>
+        {/* Action button if applicable */}
         {products.length > 0 && (
-          <button
-            onClick={() => exportToCSV(rankedData, CSV_COLUMNS, CSV_HEADERS, 'top-selling-report.csv')}
-            className="flex items-center gap-2 bg-green-600 hover:bg-green-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
-          >
-            ⬇ Export CSV
-          </button>
-        )}
+              <button
+                onClick={() => exportToCSV(rankedData, CSV_COLUMNS, CSV_HEADERS, 'top-selling-report.csv')}
+                className="flex items-center gap-2 bg-green-600 hover:bg-green-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+              >
+                ⬇ Export CSV
+              </button>
+            )}
       </div>
+    </div>
 
       {/* Error */}
       {error && (

--- a/src/pages/UserManagementPage.jsx
+++ b/src/pages/UserManagementPage.jsx
@@ -184,12 +184,16 @@ export default function UserManagementPage() {
 
       {/* Header */}
       <div className="mb-6">
-        <h2 className="text-xl font-bold text-gray-800">User Management</h2>
-        <p className="text-sm text-gray-500 mt-0.5">
-          {currentUser?.user_type === 'SUPERADMIN'
-            ? 'Manage all user accounts. SUPERADMIN accounts cannot be modified.'
-            : 'Manage registered user accounts. Activate or deactivate USER accounts.'}
-        </p>
+        <div className="flex items-start justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">User Management</h1>
+            <p className="text-sm text-gray-500 mt-1">
+              {currentUser?.user_type === 'SUPERADMIN'
+                ? 'Oversee system access levels and operational status. SUPERADMIN accounts cannot be modified.'
+                : 'Manage registered user accounts. Activate or deactivate USER accounts.'}
+            </p>
+          </div>
+        </div>
       </div>
 
       {/* Success flash */}
@@ -315,7 +319,16 @@ export default function UserManagementPage() {
                                   : 'text-green-600 hover:bg-green-50 hover:text-green-800'
                               }`}
                             >
-                              {isUpdating ? '…' : 'Activate'}
+                              {isUpdating ? '…' : (
+                                <span className="flex items-center gap-1">
+                                  {superadminRow && (
+                                    <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                                    </svg>
+                                  )}
+                                  Activate
+                                </span>
+                              )}
                             </button>
                           </div>
 
@@ -333,7 +346,16 @@ export default function UserManagementPage() {
                                   : 'text-red-500 hover:bg-red-50 hover:text-red-700'
                               }`}
                             >
-                              {isUpdating ? '…' : 'Deactivate'}
+                              {isUpdating ? '…' : (
+                                <span className="flex items-center gap-1">
+                                  {superadminRow && (
+                                    <svg xmlns="http://www.w3.org/2000/svg" className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                      <path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                                    </svg>
+                                  )}
+                                  Deactivate
+                                </span>
+                              )}
                             </button>
                           </div>
 


### PR DESCRIPTION
## What changed

Navbar.jsx
  Logo mark (blue H box), system status operational pill
  Avatar circle with initials, role badge (SUPERADMIN/ADMIN/USER coloured)
  Notification bell + settings icon (placeholder)
  Logout with icon, hidden on mobile

Sidebar.jsx
  User profile block at top: avatar, name, role badge
  All links use inline SVG icons (no emoji dependency)
  "Admin" section header divider above privileged links
  Settings + Logout at bottom separated by border
  Active link: solid blue fill (previously light blue bg)

ProductsPage.jsx
  h1 "Product Catalogue" + subtitle
  Stats sub-bar: Total Stock count, Live Price Records count
  SUPERADMIN delete restriction notice with lock icon (amber strip)

DeletedItemsPage.jsx
  Breadcrumb: Admin › Deleted Items
  h1 "Archived Products" + subtitle about audit trail
  Archived item count badge
  Column headers updated: Product ID, Item Details, Audit Stamp, Operations

UserManagementPage.jsx
  h1 "User Management" + descriptive subtitle
  US-32 FIX: SUPERADMIN rows show padlock SVG icon on
  Activate and Deactivate button labels

LoginPage.jsx
  Logo mark box above card
  "HopePMS" brand title + institution line
  "Welcome back" card header
  "Continue with Google" button (cleaner CTA text)
  Footer credit line

ProductReportPage, TopSellingPage, ActivityLogPage
  All h2 headings upgraded to h1 text-2xl font-bold text-gray-900

## User Story Audit
All 45 user stories verified — see audit table in S3-T22 guide.
US-32 gap (no lock icon on SUPERADMIN rows) — FIXED in this PR.

<img width="1907" height="920" alt="image" src="https://github.com/user-attachments/assets/235ae3b9-edc9-466b-90e1-7e6a15ced528" />
